### PR TITLE
add a struct for SurfaceAreas

### DIFF
--- a/src/BiophysicalGeometry.jl
+++ b/src/BiophysicalGeometry.jl
@@ -2,9 +2,10 @@ module BiophysicalGeometry
 
 using Unitful
 
-export AbstractGeometryModel, AbstractGeometryPars, AbstractShape, AbstractInsulation, Body
+export AbstractGeometryModel, AbstractGeometryPars, AbstractShape, AbstractInsulation, AbstractBody, Body
 export Cylinder, Sphere, Ellipsoid, Plate, LeopardFrog, DesertIguana
 export CompositeInsulation, Naked, Fur, Fat
+export SurfaceAreas
 export geometry, shape, insulation
 export total_area, skin_area, evaporation_area, skin_radius, insulation_radius, flesh_radius, flesh_volume
 export surface_area, silhouette_area, SolarOrientation, Intermediate, ParallelToSun, NormalToSun

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -88,13 +88,34 @@ Abstract supertype for organism bodies.
 abstract type AbstractBody <: AbstractGeometryPars end
 
 """
+    SurfaceAreas
+
+    SurfaceAreas(; total, skin=total, convection=total, ventral=nothing)
+
+Surface areas of an organism for heat exchange calculations.
+
+# Keywords
+
+- `total`: Total outer surface area (including insulation if present)
+- `skin`: Skin surface area (under insulation)
+- `convection`: Area available for convection (skin minus hair coverage)
+- `ventral`: Ventral surface area (for ground contact, optional)
+"""
+@kwdef struct SurfaceAreas{T,S,C,V}
+    total::T
+    skin::S = total
+    convection::C = total
+    ventral::V = nothing
+end
+
+"""
     Geometry
 
     Geometry(volume, characteristic_dimension, length, area)
 
 The geometry of an organism.
 """
-struct Geometry{V,C,L,A} <: AbstractGeometryPars
+struct Geometry{V,C,L,A<:SurfaceAreas} <: AbstractGeometryPars
     volume::V
     characteristic_dimension::C
     length::L
@@ -141,6 +162,11 @@ total_area(body::AbstractBody) = total_area(shape(body), insulation(body), body)
 skin_area(body::AbstractBody) = skin_area(shape(body), insulation(body), body)
 evaporation_area(body::AbstractBody) = evaporation_area(shape(body), insulation(body), body)
 
+# Fallbacks - mostly these are the same for all shapes
+total_area(shape::AbstrsactShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
+skin_area(shape::AbstrsactShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
+evaporation_area(shape::AbstrsactShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
+
 # for composite insulation cases (fat and fur/feathers)
 outer_insulation(ins::AbstractInsulation) = ins
 outer_insulation(ins::CompositeInsulation) = begin
@@ -153,6 +179,7 @@ outer_insulation(ins::CompositeInsulation) = begin
         ins.layers[end]
     end
 end
+
 inner_insulation(ins::AbstractInsulation) = ins
 inner_insulation(ins::CompositeInsulation) = begin
     # find fur layer if present
@@ -165,12 +192,13 @@ inner_insulation(ins::CompositeInsulation) = begin
     end
 end
 
-total_area(shape, ins::CompositeInsulation, body) =
+total_area(shape::AbstractShape, ins::CompositeInsulation, body) =
     total_area(shape, outer_insulation(ins), body)
-skin_area(shape, ins::CompositeInsulation, body) =
+skin_area(shape::AbstractShape, ins::CompositeInsulation, body) =
     skin_area(shape, outer_insulation(ins), body)
-evaporation_area(shape, ins::CompositeInsulation, body) =
+evaporation_area(shape::AbstractShape, ins::CompositeInsulation, body) =
     evaporation_area(shape, outer_insulation(ins), body)
+
 flesh_volume(body::AbstractBody) = flesh_volume(insulation(body), body)
 flesh_volume(ins::Union{Fat, CompositeInsulation}, body) = begin
     fat = inner_insulation(body.insulation)

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -163,9 +163,9 @@ skin_area(body::AbstractBody) = skin_area(shape(body), insulation(body), body)
 evaporation_area(body::AbstractBody) = evaporation_area(shape(body), insulation(body), body)
 
 # Fallbacks - mostly these are the same for all shapes
-total_area(shape::AbstractShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-skin_area(shape::AbstractShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-evaporation_area(shape::AbstractShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
+total_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.total
+skin_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.total
+evaporation_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.total
 
 # for composite insulation cases (fat and fur/feathers)
 outer_insulation(ins::AbstractInsulation) = ins

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -163,9 +163,9 @@ skin_area(body::AbstractBody) = skin_area(shape(body), insulation(body), body)
 evaporation_area(body::AbstractBody) = evaporation_area(shape(body), insulation(body), body)
 
 # Fallbacks - mostly these are the same for all shapes
-total_area(shape::AbstrsactShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-skin_area(shape::AbstrsactShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-evaporation_area(shape::AbstrsactShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
+total_area(shape::AbstractShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
+skin_area(shape::AbstractShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
+evaporation_area(shape::AbstractShape, insulation::Naked, body::AbstractBody) = body.geometry.area.total
 
 # for composite insulation cases (fat and fur/feathers)
 outer_insulation(ins::AbstractInsulation) = ins

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -167,6 +167,13 @@ total_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractB
 skin_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.total
 evaporation_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.total
 
+total_area(shape::AbstractShape, ins::CompositeInsulation, body::AbstractBody) =
+    total_area(shape, outer_insulation(ins), body)
+skin_area(shape::AbstractShape, ins::CompositeInsulation, body::AbstractBody) =
+    skin_area(shape, outer_insulation(ins), body)
+evaporation_area(shape::AbstractShape, ins::CompositeInsulation, body::AbstractBody) =
+    evaporation_area(shape, outer_insulation(ins), body)
+
 # for composite insulation cases (fat and fur/feathers)
 outer_insulation(ins::AbstractInsulation) = ins
 outer_insulation(ins::CompositeInsulation) = begin
@@ -191,13 +198,6 @@ inner_insulation(ins::CompositeInsulation) = begin
         ins.layers[end]
     end
 end
-
-total_area(shape::AbstractShape, ins::CompositeInsulation, body) =
-    total_area(shape, outer_insulation(ins), body)
-skin_area(shape::AbstractShape, ins::CompositeInsulation, body) =
-    skin_area(shape, outer_insulation(ins), body)
-evaporation_area(shape::AbstractShape, ins::CompositeInsulation, body) =
-    evaporation_area(shape, outer_insulation(ins), body)
 
 flesh_volume(body::AbstractBody) = flesh_volume(insulation(body), body)
 flesh_volume(ins::Union{Fat, CompositeInsulation}, body) = begin

--- a/src/shapes/bird.jl
+++ b/src/shapes/bird.jl
@@ -1,3 +1,5 @@
+# TODO: what is this code for
+
 """
     bird_skin_area
 

--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -14,8 +14,8 @@ function geometry(shape::Cylinder, ::Naked)
     radius_skin = (volume / (shape.b * π * 2))^(1 / 3)
     length_skin = shape.b * radius_skin * 2
     total = surface_area(shape, radius_skin, length_skin)
-    characteristic_dimension = volume^(1 / 3) # radius_skin * 2 
-    return Geometry(volume, characteristic_dimension, (; length_skin, radius_skin), (; total))
+    characteristic_dimension = volume^(1 / 3) # radius_skin * 2
+    return Geometry(volume, characteristic_dimension, (; length_skin, radius_skin), SurfaceAreas(; total))
 end
 
 function geometry(shape::Cylinder, fur::Fur)
@@ -29,7 +29,7 @@ function geometry(shape::Cylinder, fur::Fur)
     area_hair = hair_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
     characteristic_dimension = volume^(1 / 3) + fur.thickness #radius_fur * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur, length_skin, length_fur), (; total, skin, convection))
+    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur, length_skin, length_fur), SurfaceAreas(; total, skin, convection))
 end
 
 function geometry(shape::Cylinder, fat::Fat)
@@ -42,8 +42,8 @@ function geometry(shape::Cylinder, fat::Fat)
     radius_flesh = (flesh_volume / (shape.b * π * 2))^(1 / 3)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_skin, length_skin)
-    characteristic_dimension = volume^(1 / 3) # radius_skin * 2 
-    return Geometry(volume, characteristic_dimension, (; radius_skin, length_skin, fat), (; total))
+    characteristic_dimension = volume^(1 / 3) # radius_skin * 2
+    return Geometry(volume, characteristic_dimension, (; radius_skin, length_skin, fat), SurfaceAreas(; total))
 end
 
 function geometry(shape::Cylinder, fur::Fur, fat::Fat)
@@ -62,7 +62,7 @@ function geometry(shape::Cylinder, fur::Fur, fat::Fat)
     area_hair = hair_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
     characteristic_dimension = volume^(1 / 3) + fur.thickness # radius_fur * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur, length_skin, length_fur, fat), (; total, skin, convection))
+    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur, length_skin, length_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 # function surface_area(shape::Cylinder, body::AbstractBody)
@@ -116,40 +116,22 @@ function silhouette_area(shape::Cylinder, insulation::Union{Fur,CompositeInsulat
     return (; normal, parallel)
 end
 
-# area and radii functions
+# radii functions
+
+skin_radius(shape::Cylinder, insulation::AbstractInsulation, body) = body.geometry.length.radius_skin
 
 # naked
-total_area(shape::Cylinder, insulation::Naked, body) = body.geometry.area.total
-skin_area(shape::Cylinder, insulation::Naked, body) = body.geometry.area.total
-evaporation_area(shape::Cylinder, insulation::Naked, body) = body.geometry.area.total
-
-skin_radius(shape::Cylinder, insulation::Naked, body) = body.geometry.length.radius_skin
 insulation_radius(shape::Cylinder, insulation::Naked, body) = body.geometry.length.radius_skin
 flesh_radius(shape::Cylinder, insulation::Naked, body) = body.geometry.length.radius_skin
 
 # fur
-total_area(shape::Cylinder, insulation::Fur, body) = body.geometry.area.total
-skin_area(shape::Cylinder, insulation::Fur, body) = body.geometry.area.skin
-evaporation_area(shape::Cylinder, insulation::Fur, body) = body.geometry.area.convection
-
-skin_radius(shape::Cylinder, insulation::Fur, body) = body.geometry.length.radius_skin
 insulation_radius(shape::Cylinder, insulation::Fur, body) = body.geometry.length.radius_fur
 flesh_radius(shape::Cylinder, insulation::Fur, body) = body.geometry.length.radius_skin
 
 # fat
-total_area(shape::Cylinder, insulation::Fat, body) = body.geometry.area.total
-skin_area(shape::Cylinder, insulation::Fat, body) = body.geometry.area.total
-evaporation_area(shape::Cylinder, insulation::Fat, body) = body.geometry.area.total
-
-skin_radius(shape::Cylinder, insulation::Fat, body) = body.geometry.length.radius_skin
 insulation_radius(shape::Cylinder, insulation::Fat, body) = body.geometry.length.radius_skin
 flesh_radius(shape::Cylinder, insulation::Fat, body) = body.geometry.length.radius_skin - body.geometry.length.fat
 
 # fur and fat
-total_area(shape::Cylinder, insulation::CompositeInsulation, body) = body.geometry.area.total
-skin_area(shape::Cylinder, insulation::CompositeInsulation, body) = body.geometry.area.skin
-evaporation_area(shape::Cylinder, insulation::CompositeInsulation, body) = body.geometry.area.convection
-
-skin_radius(shape::Cylinder, insulation::CompositeInsulation, body) = body.geometry.length.radius_skin
 insulation_radius(shape::Cylinder, insulation::CompositeInsulation, body) = body.geometry.length.radius_fur
 flesh_radius(shape::Cylinder, insulation::CompositeInsulation, body) = body.geometry.length.radius_skin - body.geometry.length.fat

--- a/src/shapes/desert_iguana.jl
+++ b/src/shapes/desert_iguana.jl
@@ -13,7 +13,7 @@ function geometry(shape::DesertIguana, ::Naked)
     characteristic_dimension = volume^(1 / 3)
     r_skin = (volume / (4 * π)) ^ (1 / 3)
     total, ventral = surface_area(shape)
-    return Geometry(volume, characteristic_dimension, (; r_skin), (; total, ventral))
+    return Geometry(volume, characteristic_dimension, (; r_skin), SurfaceAreas(; total, ventral))
 end
 
 # area functions
@@ -44,10 +44,7 @@ function silhouette_area(shape::DesertIguana, ::Intermediate)
     return (normal + parallel) * 0.5
 end
 
-# surface area and radii functions
-total_area(shape::DesertIguana, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-skin_area(shape::DesertIguana, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-evaporation_area(shape::DesertIguana, insulation::Naked, body::AbstractBody) = body.geometry.area.total
+# radii functions
 
 skin_radius(shape::DesertIguana, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin
 insulation_radius(shape::DesertIguana, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin

--- a/src/shapes/ellipsoid.jl
+++ b/src/shapes/ellipsoid.jl
@@ -18,7 +18,7 @@ function geometry(shape::Ellipsoid, ::Naked)
     e = ((ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) ^ (1 / 2)) / ustrip(u"m", a_semi_major_skin)
     total = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", b_semi_minor_skin), e)
     characteristic_dimension = volume^(1 / 3) # b_semi_minor_skin * 2
-    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin), (; total))
+    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin), SurfaceAreas(; total))
 end
 
 function geometry(shape::Ellipsoid, fur::Fur)
@@ -37,7 +37,7 @@ function geometry(shape::Ellipsoid, fur::Fur)
     area_hair = hair_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair 
     characteristic_dimension = volume^(1 / 3) + fur.thickness # b_semi_minor_fur * 2
-    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur), (; total, skin, convection))
+    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur), SurfaceAreas(; total, skin, convection))
 end
 
 function geometry(shape::Ellipsoid, fat::Fat)
@@ -65,7 +65,7 @@ function geometry(shape::Ellipsoid, fat::Fat)
     e = ((a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) ^ (1 / 2)) / a_semi_major_skin
     total = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
     characteristic_dimension = volume^(1 / 3) # b_semi_minor_skin * 2
-    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, fat), (; total))
+    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, fat), SurfaceAreas(; total))
 end
 
 function geometry(shape::Ellipsoid, fur::Fur, fat::Fat)
@@ -101,7 +101,7 @@ function geometry(shape::Ellipsoid, fur::Fur, fat::Fat)
     area_hair = hair_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair 
     characteristic_dimension = volume^(1 / 3) + fur.thickness # b_semi_minor_fur * 2
-    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur, fat), (; total, skin, convection))
+    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 # fat thickness calculation
@@ -239,40 +239,21 @@ function silhouette_area(shape::Ellipsoid, insulation::CompositeInsulation, body
     return silhouette_area(shape, a, b, c, θ)
 end
 
-# area and radii functions
+# radii functions
+skin_radius(shape::Ellipsoid, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 
 # naked
-total_area(shape::Ellipsoid, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-skin_area(shape::Ellipsoid, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-evaporation_area(shape::Ellipsoid, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-
-skin_radius(shape::Ellipsoid, insulation::Naked, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 insulation_radius(shape::Ellipsoid, insulation::Naked, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 flesh_radius(shape::Ellipsoid, insulation::Naked, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 
 # fur
-total_area(shape::Ellipsoid, insulation::Fur, body::AbstractBody) = body.geometry.area.total
-skin_area(shape::Ellipsoid, insulation::Fur, body::AbstractBody) = body.geometry.area.skin
-evaporation_area(shape::Ellipsoid, insulation::Fur, body::AbstractBody) = body.geometry.area.convection
-
-skin_radius(shape::Ellipsoid, insulation::Fur, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 insulation_radius(shape::Ellipsoid, insulation::Fur, body::AbstractBody) = body.geometry.length.b_semi_minor_fur
 flesh_radius(shape::Ellipsoid, insulation::Fur, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 
 # fat
-total_area(shape::Ellipsoid, insulation::Fat, body::AbstractBody) = body.geometry.area.total
-skin_area(shape::Ellipsoid, insulation::Fat, body::AbstractBody) = body.geometry.area.total
-evaporation_area(shape::Ellipsoid, insulation::Fat, body::AbstractBody) = body.geometry.area.total
-
-skin_radius(shape::Ellipsoid, insulation::Fat, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 insulation_radius(shape::Ellipsoid, insulation::Fat, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 flesh_radius(shape::Ellipsoid, insulation::Fat, body::AbstractBody) = body.geometry.length.b_semi_minor_skin - body.geometry.length.fat
 
 # fur and fat
-total_area(shape::Ellipsoid, insulation::CompositeInsulation, body::AbstractBody) = body.geometry.area.total
-skin_area(shape::Ellipsoid, insulation::CompositeInsulation, body::AbstractBody) = body.geometry.area.skin
-evaporation_area(shape::Ellipsoid, insulation::CompositeInsulation, body::AbstractBody) = body.geometry.area.convection
-
-skin_radius(shape::Ellipsoid, insulation::CompositeInsulation, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 insulation_radius(shape::Ellipsoid, insulation::CompositeInsulation, body::AbstractBody) = body.geometry.length.b_semi_minor_fur
 flesh_radius(shape::Ellipsoid, insulation::CompositeInsulation, body::AbstractBody) = body.geometry.length.b_semi_minor_skin - body.geometry.length.fat

--- a/src/shapes/leopard_frog.jl
+++ b/src/shapes/leopard_frog.jl
@@ -13,7 +13,7 @@ function geometry(shape::LeopardFrog, ::Naked)
     characteristic_dimension = volume^(1 / 3)
     r_skin = (volume / (4 * π)) ^ (1 / 3)
     total = surface_area(shape)
-    return Geometry(volume, characteristic_dimension, (; r_skin), (; total))
+    return Geometry(volume, characteristic_dimension, (; r_skin), SurfaceAreas(; total))
 end
 
 # area functions
@@ -33,9 +33,6 @@ function silhouette_area(shape::LeopardFrog, θ)
 end
 
 # surface area and radii functions
-total_area(shape::LeopardFrog, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-skin_area(shape::LeopardFrog, insulation::Naked, body::AbstractBody) = body.geometry.area.total
-evaporation_area(shape::LeopardFrog, insulation::Naked, body::AbstractBody) = body.geometry.area.total
 
 # "radii" functions
 skin_radius(shape::LeopardFrog, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin

--- a/src/shapes/mammal.jl
+++ b/src/shapes/mammal.jl
@@ -1,3 +1,5 @@
+# TODO: what is this code for
+
 """
     mammal_skin_area
 

--- a/src/shapes/plate.jl
+++ b/src/shapes/plate.jl
@@ -17,7 +17,7 @@ function geometry(shape::Plate, ::Naked)
     height_skin = length_skin / shape.c 
     total = surface_area(shape, length_skin, width_skin, height_skin)
     characteristic_dimension = volume^(1 / 3) # width_skin * 2
-    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin), (; total))
+    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin), SurfaceAreas(; total))
 end
 
 function geometry(shape::Plate, fur::Fur)
@@ -34,7 +34,7 @@ function geometry(shape::Plate, fur::Fur)
     convection = skin - area_hair
     fat = 0.0u"m"
     characteristic_dimension = volume^(1 / 3) + fur.thickness # width_fur * 2
-    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), (; total, skin, convection))
+    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 function geometry(shape::Plate, fat::Fat)
@@ -49,7 +49,7 @@ function geometry(shape::Plate, fat::Fat)
     fat = (width_skin - width_flesh) / 2
     total = surface_area(shape, length_skin, width_skin, height_skin)
     characteristic_dimension = volume^(1 / 3) # width_skin * 2 
-    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin, fat), (; total))
+    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin, fat), SurfaceAreas(; total))
 end
 
 function geometry(shape::Plate, fur::Fur, fat::Fat)
@@ -70,7 +70,7 @@ function geometry(shape::Plate, fur::Fur, fat::Fat)
     area_hair = hair_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
     characteristic_dimension = volume^(1 / 3) + fur.thickness #width_fur * 2 
-    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), (; total, skin, convection))
+    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 # surface area functions
@@ -103,40 +103,22 @@ function silhouette_area(shape::Plate, insulation::Union{Fur,CompositeInsulation
     return (; normal, parallel)
 end
 
-# area and radii functions
+# radii functions
+
+skin_radius(shape::Plate, insulation::AbstractInsulation, body) = body.geometry.length.width_skin / 2
 
 # naked
-total_area(shape::Plate, insulation::Naked, body) = body.geometry.area.total
-skin_area(shape::Plate, insulation::Naked, body) = body.geometry.area.total
-evaporation_area(shape::Plate, insulation::Naked, body) = body.geometry.area.total
-
-skin_radius(shape::Plate, insulation::Naked, body) = body.geometry.length.width_skin / 2
 insulation_radius(shape::Plate, insulation::Naked, body) = body.geometry.length.width_skin / 2
 flesh_radius(shape::Plate, insulation::Naked, body) = body.geometry.length.width_skin / 2
 
 # fur
-total_area(shape::Plate, insulation::Fur, body) = body.geometry.area.total
-skin_area(shape::Plate, insulation::Fur, body) = body.geometry.area.skin
-evaporation_area(shape::Plate, insulation::Fur, body) = body.geometry.area.convection
-
-skin_radius(shape::Plate, insulation::Fur, body) = body.geometry.length.width_skin / 2
 insulation_radius(shape::Plate, insulation::Fur, body) = body.geometry.length.width_fur / 2
 flesh_radius(shape::Plate, insulation::Fur, body) = body.geometry.length.width_skin / 2
 
 # fat
-total_area(shape::Plate, insulation::Fat, body) = body.geometry.area.total
-skin_area(shape::Plate, insulation::Fat, body) = body.geometry.area.total
-evaporation_area(shape::Plate, insulation::Fat, body) = body.geometry.area.total
-
-skin_radius(shape::Plate, insulation::Fat, body) = body.geometry.length.width_skin / 2
 insulation_radius(shape::Plate, insulation::Fat, body) = body.geometry.length.width_skin / 2
 flesh_radius(shape::Plate, insulation::Fat, body) = body.geometry.length.width_skin / 2 - body.geometry.length.fat
 
 # fur plus fat
-total_area(shape::Plate, insulation::CompositeInsulation, body) = body.geometry.area.total
-skin_area(shape::Plate, insulation::CompositeInsulation, body) = body.geometry.area.skin
-evaporation_area(shape::Plate, insulation::CompositeInsulation, body) = body.geometry.area.convection
-
-skin_radius(shape::Plate, insulation::CompositeInsulation, body) = body.geometry.length.width_skin / 2
 insulation_radius(shape::Plate, insulation::CompositeInsulation, body) = body.geometry.length.width_fur / 2
 flesh_radius(shape::Plate, insulation::CompositeInsulation, body) = body.geometry.length.width_skin / 2 - body.geometry.length.fat

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -13,7 +13,7 @@ function geometry(shape::Sphere, ::Naked)
     radius_skin = ((3 / 4) * volume / π) ^ (1 / 3)
     total = surface_area(shape, radius_skin)
     characteristic_dimension = volume^(1 / 3) #radius_skin * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin), (; total))
+    return Geometry(volume, characteristic_dimension, (; radius_skin), SurfaceAreas(; total))
 end
 
 function geometry(shape::Sphere, fur::Fur)
@@ -25,7 +25,7 @@ function geometry(shape::Sphere, fur::Fur)
     area_hair = hair_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
     characteristic_dimension = volume^(1 / 3) + fur.thickness # radius_fur * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur), (; total, skin, convection))
+    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur), SurfaceAreas(; total, skin, convection))
 end
 
 function geometry(shape::Sphere, fat::Fat)
@@ -38,14 +38,14 @@ function geometry(shape::Sphere, fat::Fat)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_skin)
     characteristic_dimension = volume^(1 / 3) #radius_skin * 2 #
-    return Geometry(volume, characteristic_dimension, (; radius_skin, fat), (; total))
+    return Geometry(volume, characteristic_dimension, (; radius_skin, fat), SurfaceAreas(; total))
 end
 
 function geometry(shape::Sphere, fur::Fur, fat::Fat)
     volume = shape.mass / shape.density
     fat_mass = shape.mass * fat.fraction
     fat_volume = fat_mass / fat.density
-    flesh_volume = volume - fat_volume    
+    flesh_volume = volume - fat_volume
     radius_skin = ((3 / 4) * volume / π) ^ (1 / 3)
     radius_fur = radius_skin + fur.thickness
     radius_flesh = ((3 / 4) * flesh_volume / π) ^ (1 / 3)
@@ -55,7 +55,7 @@ function geometry(shape::Sphere, fur::Fur, fat::Fat)
     area_hair = hair_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
     characteristic_dimension = volume^(1 / 3) + fur.thickness #radius_fur * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur, fat), (; total, skin, convection))
+    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 # area functions
@@ -98,40 +98,22 @@ function silhouette_area(shape::Sphere, insulation::Union{Fur,CompositeInsulatio
     return (; normal, parallel)
 end
 
-# area and radii functions
+# radii functions
+
+skin_radius(shape::Sphere, insulation::AbstractInsulation, body) = body.geometry.length.radius_skin
 
 # naked
-total_area(shape::Sphere, insulation::Naked, body) = body.geometry.area.total
-skin_area(shape::Sphere, insulation::Naked, body) = body.geometry.area.total
-evaporation_area(shape::Sphere, insulation::Naked, body) = body.geometry.area.total
-
-skin_radius(shape::Sphere, insulation::Naked, body) = body.geometry.length.radius_skin
 insulation_radius(shape::Sphere, insulation::Naked, body) = body.geometry.length.radius_skin
 flesh_radius(shape::Sphere, insulation::Naked, body) = body.geometry.length.radius_skin
 
 # fur
-total_area(shape::Sphere, insulation::Fur, body) = body.geometry.area.total
-skin_area(shape::Sphere, insulation::Fur, body) = body.geometry.area.skin
-evaporation_area(shape::Sphere, insulation::Fur, body) = body.geometry.area.convection
-
-skin_radius(shape::Sphere, insulation::Fur, body) = body.geometry.length.radius_skin
 insulation_radius(shape::Sphere, insulation::Fur, body) = body.geometry.length.radius_fur
 flesh_radius(shape::Sphere, insulation::Fur, body) = body.geometry.length.radius_skin
 
 # fat
-total_area(shape::Sphere, insulation::Fat, body) = body.geometry.area.total
-skin_area(shape::Sphere, insulation::Fat, body) = body.geometry.area.total
-evaporation_area(shape::Sphere, insulation::Fat, body) = body.geometry.area.total
-
-skin_radius(shape::Sphere, insulation::Fat, body) = body.geometry.length.radius_skin
 insulation_radius(shape::Sphere, insulation::Fat, body) = body.geometry.length.radius_skin
 flesh_radius(shape::Sphere, insulation::Fat, body) = body.geometry.length.radius_skin - body.geometry.length.fat
 
 # fur and fat
-total_area(shape::Sphere, insulation::CompositeInsulation, body) = body.geometry.area.total
-skin_area(shape::Sphere, insulation::CompositeInsulation, body) = body.geometry.area.skin
-evaporation_area(shape::Sphere, insulation::CompositeInsulation, body) = body.geometry.area.convection
-
-skin_radius(shape::Sphere, insulation::CompositeInsulation, body) = body.geometry.length.radius_skin
 insulation_radius(shape::Sphere, insulation::CompositeInsulation, body) = body.geometry.length.radius_fur
 flesh_radius(shape::Sphere, insulation::CompositeInsulation, body) = body.geometry.length.radius_skin - body.geometry.length.fat


### PR DESCRIPTION
Adds a SurfaceAreas struct, with a default that skin and convection areas equal the total. 

This clean up a lot of getters as we can always just get the total, skin or convection area rather than needing to override so skin == total.