### PR TITLE
update insulation terms, remove characteristic dimension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Manifest.toml
 test/R/.Rhistory
 Manifest.toml
+.claude/settings.json
+.claude/settings.local.json

--- a/examples/cross_sections_2d.jl
+++ b/examples/cross_sections_2d.jl
@@ -23,10 +23,10 @@ shape      = Cylinder(mass, density, 4.0)
 # shape    = Ellipsoid(mass, density, 4.0, 1.0)
 # shape    = Sphere(mass, density)
 
-insulation = CompositeInsulation(Fur(10.0u"mm", 30.0u"μm", 3000u"cm^-2"),
-                                  Fat(0.1, 901.0u"kg/m^3"))
-# insulation = Fur(10.0u"mm", 30.0u"μm", 3000u"cm^-2")
-# insulation = Fat(0.1, 901.0u"kg/m^3")
+insulation = CompositeInsulation(FibrousLayer(10.0u"mm", 30.0u"μm", 3000u"cm^-2"),
+                                  FatLayer(0.1, 901.0u"kg/m^3"))
+# insulation = FibrousLayer(10.0u"mm", 30.0u"μm", 3000u"cm^-2")
+# insulation = FatLayer(0.1, 901.0u"kg/m^3")
 # insulation = Naked()
 
 body = Body(shape, insulation)

--- a/examples/insulation_properties.jl
+++ b/examples/insulation_properties.jl
@@ -1,11 +1,11 @@
 # insulation_properties.jl
 #
-# Visualises the properties of fur/fibre insulation as modelled in
+# Visualises the properties of fibrous insulation layers as modelled in
 # BiophysicalGeometry.jl.  Four panels:
 #
-#   1. Fur schematic — side-view cartoon showing fibre diameter d, fur depth
-#      (thickness), fibre length L, and the inter-fibre spacing implied by N.
-#      When L > fur depth the fibres are drawn as tilted parallelograms.
+#   1. FibrousLayer schematic — side-view cartoon showing fibre diameter d, layer
+#      depth (thickness), fibre length L, and the inter-fibre spacing implied by N.
+#      When L > layer depth the fibres are drawn as tilted parallelograms.
 #
 #   2. Coverage fraction heatmap — fraction of skin area occupied by fibre
 #      cross-sections as a function of d and N.
@@ -37,17 +37,17 @@ density = 1000.0u"kg/m^3"
 b_ratio = 4.0
 
 insulation_depth = 10.0u"mm"
-fibre_length     = 14.0u"mm"   # actual fibre length (may exceed fur depth → fibres tilt)
+fibre_length     = 14.0u"mm"   # actual fibre length (may exceed layer depth → fibres tilt)
 fibre_diameter   = 30.0u"μm"
 fibre_density    = 3000u"cm^-2"
 
-fur  = Fur(insulation_depth, fibre_diameter, fibre_density)
-fat  = Fat(0.1, 901.0u"kg/m^3")
-comp = CompositeInsulation(fur, fat)
+fibrous_layer = FibrousLayer(insulation_depth, fibre_diameter, fibre_density)
+fat_layer     = FatLayer(0.1, 901.0u"kg/m^3")
+comp          = CompositeInsulation(fibrous_layer, fat_layer)
 
 cyl        = Cylinder(mass, density, b_ratio)
-ins_list   = [Naked(), fat, fur, comp]
-ins_labels = ["Naked", "Fat", "Fur", "Fur + Fat"]
+ins_list   = [Naked(), fat_layer, fibrous_layer, comp]
+ins_labels = ["Naked", "FatLayer", "FibrousLayer", "FibrousLayer + FatLayer"]
 
 # ── Panel 3: Surface area comparison bar chart ────────────────────────────────
 
@@ -120,10 +120,10 @@ ax2 = Axis(fig[1, 2])
 ax3 = Axis(fig[2, 1])
 ax4 = Axis(fig[2, 2:3])
 
-draw_insulation_schematic!(ax1, fur; fibre_length)
-hm = draw_insulation_coverage!(ax2, fur)
+draw_insulation_schematic!(ax1, fibrous_layer; fibre_length)
+hm = draw_insulation_coverage!(ax2, fibrous_layer)
 draw_area_comparison!(ax3, cyl, ins_list, ins_labels)
-draw_silhouette_vs_zenith!(ax4, cyl, [Naked(), fur, comp], ["Naked", "Fur", "Fur + Fat"])
+draw_silhouette_vs_zenith!(ax4, cyl, [Naked(), fibrous_layer, comp], ["Naked", "FibrousLayer", "FibrousLayer + FatLayer"])
 
 Colorbar(fig[1, 3], hm; label="Coverage fraction f", width=14, labelsize=10)
 

--- a/examples/shapes_3d.jl
+++ b/examples/shapes_3d.jl
@@ -39,10 +39,10 @@ shape = Cylinder(mass, density, b_ratio)
 # shape = Sphere(mass, density)
 # shape = Ellipsoid(mass, density, b_ratio, 1.0)
 
-insulation = CompositeInsulation(Fur(10.0u"mm", 30.0u"μm", 3000u"cm^-2"),
-                                  Fat(0.1, 901.0u"kg/m^3"))
-# insulation = Fur(10.0u"mm", 30.0u"μm", 3000u"cm^-2")
-# insulation = Fat(0.1, 901.0u"kg/m^3")
+insulation = CompositeInsulation(FibrousLayer(10.0u"mm", 30.0u"μm", 3000u"cm^-2"),
+                                  FatLayer(0.1, 901.0u"kg/m^3"))
+# insulation = FibrousLayer(10.0u"mm", 30.0u"μm", 3000u"cm^-2")
+# insulation = FatLayer(0.1, 901.0u"kg/m^3")
 # insulation = Naked()
 
 body = Body(shape, insulation)

--- a/ext/BiophysicalGeometryMakieExt.jl
+++ b/ext/BiophysicalGeometryMakieExt.jl
@@ -20,12 +20,12 @@ function _scaled_radii(body, sc)
      ins  =ustrip(u"m", r.ins)   * sc)
 end
 
-_layer_flags(r) = (fat=r.skin > r.flesh + 1e-9, fur=r.ins > r.skin + 1e-9)
+_layer_flags(r) = (fat_layer=r.skin > r.flesh + 1e-9, fibrous_layer=r.ins > r.skin + 1e-9)
 
 _axis_ratio(::Any)        = 1.0
 _axis_ratio(s::Ellipsoid) = Float64(s.b)
 
-_colors(p) = (flesh=p[:flesh_col][], fat=p[:fat_col][], fur=p[:fur_col][])
+_colors(p) = (flesh=p[:flesh_col][], fat_layer=p[:fat_layer_col][], fibrous_layer=p[:fibrous_layer_col][])
 
 _limits(lx, ly, tx, ty) = (
     long_x=(-lx, lx), long_y=(-ly, ly),
@@ -122,8 +122,8 @@ function _draw_cutaway_shape!(p, ::Cylinder, body, sc, cols)
     z0_fur = -(L_i - L_s) / 2
 
     _draw_cylinder!(p, r.flesh, L_s, cols.flesh)
-    fl.fat && _draw_cylinder!(p, r.skin, L_s, cols.fat; θ_end=3π/2)
-    fl.fur && _draw_cylinder!(p, r.ins,  L_i, cols.fur; θ_end=3π/2, z0=z0_fur)
+    fl.fat_layer && _draw_cylinder!(p, r.skin, L_s, cols.fat_layer; θ_end=3π/2)
+    fl.fibrous_layer && _draw_cylinder!(p, r.ins,  L_i, cols.fibrous_layer; θ_end=3π/2, z0=z0_fur)
 end
 
 function _draw_cutaway_shape!(p, shape::Union{Sphere,Ellipsoid}, body, sc, cols)
@@ -132,8 +132,8 @@ function _draw_cutaway_shape!(p, shape::Union{Sphere,Ellipsoid}, body, sc, cols)
     ratio = _axis_ratio(shape)
 
     _draw_surface!(p, _ellipsoid_mesh(r.flesh * ratio, r.flesh), cols.flesh)
-    fl.fat && _draw_surface!(p, _ellipsoid_mesh(r.skin * ratio, r.skin; θ_end=3π/2), cols.fat)
-    fl.fur && _draw_surface!(p, _ellipsoid_mesh(r.ins  * ratio, r.ins;  θ_end=3π/2), cols.fur)
+    fl.fat_layer && _draw_surface!(p, _ellipsoid_mesh(r.skin * ratio, r.skin; θ_end=3π/2), cols.fat_layer)
+    fl.fibrous_layer && _draw_surface!(p, _ellipsoid_mesh(r.ins  * ratio, r.ins;  θ_end=3π/2), cols.fibrous_layer)
 end
 
 function _draw_cutaway_shape!(p, shape::Plate, body, sc, cols)
@@ -152,8 +152,8 @@ function _draw_cutaway_shape!(p, shape::Plate, body, sc, cols)
     hh_f = hl_f / Float64(shape.c)
 
     _draw_box_faces!(p, hl_f, hw_f, hh_f, cols.flesh; full=true)
-    fl.fat && _draw_box_faces!(p, hl_s, hw_s, hh_s, cols.fat)
-    fl.fur && _draw_box_faces!(p, hl_i, hw_i, hh_i, cols.fur)
+    fl.fat_layer && _draw_box_faces!(p, hl_s, hw_s, hh_s, cols.fat_layer)
+    fl.fibrous_layer && _draw_box_faces!(p, hl_i, hw_i, hh_i, cols.fibrous_layer)
 end
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -183,14 +183,14 @@ function _section_layers(::Cylinder, body, mode, r, cols)
     hl_i = _get(gl, :length_fur, gl.length_skin) / 2
     if mode === :long
         [
-            (r_i > r_s, () -> _rect_pts(r_i, hl_i), cols.fur),
-            (r_s > r_f, () -> _rect_pts(r_s, hl_s), cols.fat),
+            (r_i > r_s, () -> _rect_pts(r_i, hl_i), cols.fibrous_layer),
+            (r_s > r_f, () -> _rect_pts(r_s, hl_s), cols.fat_layer),
             (true,      () -> _rect_pts(r_f, hl_s),  cols.flesh),
         ]
     else
         [
-            (r_i > r_s, () -> _circle_pts(r_i), cols.fur),
-            (r_s > r_f, () -> _circle_pts(r_s), cols.fat),
+            (r_i > r_s, () -> _circle_pts(r_i), cols.fibrous_layer),
+            (r_s > r_f, () -> _circle_pts(r_s), cols.fat_layer),
             (true,      () -> _circle_pts(r_f), cols.flesh),
         ]
     end
@@ -209,8 +209,8 @@ function _section_layers(shape::Plate, body, mode, r, cols)
         d_f = (r_f, (r_f * shape.b) / shape.c)
     end
     [
-        (r_i > r_s, () -> _rect_pts(d_i...), cols.fur),
-        (r_s > r_f, () -> _rect_pts(d_s...), cols.fat),
+        (r_i > r_s, () -> _rect_pts(d_i...), cols.fibrous_layer),
+        (r_s > r_f, () -> _rect_pts(d_s...), cols.fat_layer),
         (true,      () -> _rect_pts(d_f...),  cols.flesh),
     ]
 end
@@ -220,8 +220,8 @@ function _section_layers(shape::Union{Sphere,Ellipsoid}, _, mode, r, cols)
     ratio = _axis_ratio(shape)
     geom  = mode === :long ? x -> _ellipse_pts(x, x * ratio) : _circle_pts
     [
-        (r_i > r_s, () -> geom(r_i), cols.fur),
-        (r_s > r_f, () -> geom(r_s), cols.fat),
+        (r_i > r_s, () -> geom(r_i), cols.fibrous_layer),
+        (r_s > r_f, () -> geom(r_s), cols.fat_layer),
         (true,      () -> geom(r_f), cols.flesh),
     ]
 end
@@ -262,8 +262,8 @@ end
 @recipe(BodyCutaway, body) do scene
     Theme(
         flesh_col = RGBAf(0.88, 0.48, 0.42, 1.00),
-        fat_col   = RGBAf(1.00, 0.97, 0.60, 0.75),
-        fur_col   = RGBAf(0.76, 0.62, 0.42, 0.45),
+        fat_layer_col   = RGBAf(1.00, 0.97, 0.60, 0.75),
+        fibrous_layer_col   = RGBAf(0.76, 0.62, 0.42, 0.45),
         sc        = 100.0,
     )
 end
@@ -277,8 +277,8 @@ end
 @recipe(BodyLongSection, body) do scene
     Theme(
         flesh_col = RGBf(0.88, 0.48, 0.42),
-        fat_col   = RGBf(1.00, 0.97, 0.60),
-        fur_col   = RGBf(0.76, 0.62, 0.42),
+        fat_layer_col   = RGBf(1.00, 0.97, 0.60),
+        fibrous_layer_col   = RGBf(0.76, 0.62, 0.42),
     )
 end
 
@@ -291,8 +291,8 @@ end
 @recipe(BodyTransSection, body) do scene
     Theme(
         flesh_col = RGBf(0.88, 0.48, 0.42),
-        fat_col   = RGBf(1.00, 0.97, 0.60),
-        fur_col   = RGBf(0.76, 0.62, 0.42),
+        fat_layer_col   = RGBf(1.00, 0.97, 0.60),
+        fibrous_layer_col   = RGBf(0.76, 0.62, 0.42),
     )
 end
 
@@ -307,7 +307,7 @@ end
 # ══════════════════════════════════════════════════════════════════════════════
 
 """
-    draw_cutaway!(ax::Axis3, body; sc=100.0, flesh_col=…, fat_col=…, fur_col=…)
+    draw_cutaway!(ax::Axis3, body; sc=100.0, flesh_col=…, fat_layer_col=…, fibrous_layer_col=…)
 
 Draw a quarter-cutaway 3-D surface mesh of `body` into an existing `Axis3`.
 `sc` converts metres to axis units (default 100 → cm labels).
@@ -315,14 +315,14 @@ Draw a quarter-cutaway 3-D surface mesh of `body` into an existing `Axis3`.
 function BiophysicalGeometry.draw_cutaway!(ax, body;
         sc        = 100.0,
         flesh_col = RGBAf(0.88, 0.48, 0.42, 1.00),
-        fat_col   = RGBAf(1.00, 0.97, 0.60, 0.75),
-        fur_col   = RGBAf(0.76, 0.62, 0.42, 0.45))
-    bodycutaway!(ax, body; sc, flesh_col, fat_col, fur_col)
+        fat_layer_col   = RGBAf(1.00, 0.97, 0.60, 0.75),
+        fibrous_layer_col   = RGBAf(0.76, 0.62, 0.42, 0.45))
+    bodycutaway!(ax, body; sc, flesh_col, fat_layer_col, fibrous_layer_col)
     ax.xlabel = "x (cm)"; ax.ylabel = "y (cm)"; ax.zlabel = "z (cm)"
 end
 
 """
-    plot_body(body; sc=100.0, flesh_col=…, fat_col=…, fur_col=…) -> Figure
+    plot_body(body; sc=100.0, flesh_col=…, fat_layer_col=…, fibrous_layer_col=…) -> Figure
 
 Create a labelled `Figure` with `Axis3`, draw a quarter-cutaway of `body`,
 and attach a legend. Returns the `Figure`.
@@ -330,8 +330,8 @@ and attach a legend. Returns the `Figure`.
 function BiophysicalGeometry.plot_body(body;
         sc        = 100.0,
         flesh_col = RGBAf(0.88, 0.48, 0.42, 1.00),
-        fat_col   = RGBAf(1.00, 0.97, 0.60, 0.75),
-        fur_col   = RGBAf(0.76, 0.62, 0.42, 0.45))
+        fat_layer_col   = RGBAf(1.00, 0.97, 0.60, 0.75),
+        fibrous_layer_col   = RGBAf(0.76, 0.62, 0.42, 0.45))
 
     shape_name = string(nameof(typeof(body.shape)))
     ins_name   = string(nameof(typeof(body.insulation)))
@@ -343,18 +343,18 @@ function BiophysicalGeometry.plot_body(body;
     ax = Axis3(fig[1, 1];
                perspectiveness=0.5, viewmode=:fit, aspect=:data,
                elevation=π/7, azimuth=5π/4)
-    draw_cutaway!(ax, body; sc, flesh_col, fat_col, fur_col)
+    draw_cutaway!(ax, body; sc, flesh_col, fat_layer_col, fibrous_layer_col)
     Legend(fig[2, 1],
         [PolyElement(polycolor=flesh_col, strokecolor=:saddlebrown, strokewidth=1),
-         PolyElement(polycolor=fat_col,   strokecolor=:saddlebrown, strokewidth=1),
-         PolyElement(polycolor=fur_col,   strokecolor=:black,       strokewidth=1)],
-        ["Flesh / muscle", "Subcutaneous fat", "Fur / insulation"];
+         PolyElement(polycolor=fat_layer_col,   strokecolor=:saddlebrown, strokewidth=1),
+         PolyElement(polycolor=fibrous_layer_col,   strokecolor=:black,       strokewidth=1)],
+        ["Flesh / muscle", "Subcutaneous fat layer", "Fibrous insulation layer"];
         orientation=:horizontal, framevisible=false)
     return fig
 end
 
 """
-    draw_cross_sections!(ax_long, ax_tran, body; flesh_col=…, fat_col=…, fur_col=…)
+    draw_cross_sections!(ax_long, ax_tran, body; flesh_col=…, fat_layer_col=…, fibrous_layer_col=…)
 
 Draw longitudinal and transverse cross-section polygons into a pair of `Axis`
 objects.  Layers are drawn outer-to-inner so each inner layer paints over the
@@ -362,11 +362,11 @@ outer one.
 """
 function BiophysicalGeometry.draw_cross_sections!(ax_long, ax_tran, body;
         flesh_col = RGBf(0.88, 0.48, 0.42),
-        fat_col   = RGBf(1.00, 0.97, 0.60),
-        fur_col   = RGBf(0.76, 0.62, 0.42))
+        fat_layer_col   = RGBf(1.00, 0.97, 0.60),
+        fibrous_layer_col   = RGBf(0.76, 0.62, 0.42))
 
-    bodylongsection!(ax_long, body; flesh_col, fat_col, fur_col)
-    bodytranssection!(ax_tran, body; flesh_col, fat_col, fur_col)
+    bodylongsection!(ax_long, body; flesh_col, fat_layer_col, fibrous_layer_col)
+    bodytranssection!(ax_tran, body; flesh_col, fat_layer_col, fibrous_layer_col)
 
     r    = _radii(body)
     lims = _section_limits(body.shape, body, r, 0.12)
@@ -375,15 +375,15 @@ function BiophysicalGeometry.draw_cross_sections!(ax_long, ax_tran, body;
 end
 
 """
-    plot_cross_sections(body; flesh_col=…, fat_col=…, fur_col=…) -> Figure
+    plot_cross_sections(body; flesh_col=…, fat_layer_col=…, fibrous_layer_col=…) -> Figure
 
 Create a two-panel `Figure` (longitudinal + transverse cross-sections) with
 legend. Returns the `Figure`.
 """
 function BiophysicalGeometry.plot_cross_sections(body;
         flesh_col = RGBf(0.88, 0.48, 0.42),
-        fat_col   = RGBf(1.00, 0.97, 0.60),
-        fur_col   = RGBf(0.76, 0.62, 0.42))
+        fat_layer_col   = RGBf(1.00, 0.97, 0.60),
+        fibrous_layer_col   = RGBf(0.76, 0.62, 0.42))
 
     shape_name = string(nameof(typeof(body.shape)))
     ins_name   = string(nameof(typeof(body.insulation)))
@@ -398,12 +398,12 @@ function BiophysicalGeometry.plot_cross_sections(body;
     ax_tran = Axis(fig[1, 2];
                    title="Transverse section",
                    xlabel="x (cm)", ylabel="y (cm)", aspect=DataAspect())
-    draw_cross_sections!(ax_long, ax_tran, body; flesh_col, fat_col, fur_col)
+    draw_cross_sections!(ax_long, ax_tran, body; flesh_col, fat_layer_col, fibrous_layer_col)
     Legend(fig[2, 1:2],
         [PolyElement(polycolor=flesh_col, strokecolor=flesh_col, strokewidth=1),
-         PolyElement(polycolor=fat_col,   strokecolor=fat_col,   strokewidth=1),
-         PolyElement(polycolor=fur_col,   strokecolor=fur_col,   strokewidth=1)],
-        ["Flesh / muscle", "Subcutaneous fat", "Fur / fibre insulation"];
+         PolyElement(polycolor=fat_layer_col,   strokecolor=fat_layer_col,   strokewidth=1),
+         PolyElement(polycolor=fibrous_layer_col,   strokecolor=fibrous_layer_col,   strokewidth=1)],
+        ["Flesh / muscle", "Subcutaneous fat layer", "Fibrous insulation layer"];
         orientation=:horizontal, framevisible=false)
     rowgap!(fig.layout, 8)
     colgap!(fig.layout, 30)
@@ -411,19 +411,19 @@ function BiophysicalGeometry.plot_cross_sections(body;
 end
 
 """
-    draw_insulation_schematic!(ax, fur::Fur; fibre_length=fur.thickness)
+    draw_insulation_schematic!(ax, fibrous_layer::FibrousLayer; fibre_length=fibrous_layer.thickness)
 
-Draw a side-view schematic of a `Fur` insulation layer into `ax`.  Fibre width
-is exaggerated for clarity.  When `fibre_length > fur.thickness` the fibres are
+Draw a side-view schematic of a [`FibrousLayer`](@ref) insulation into `ax`.  Fibre width
+is exaggerated for clarity.  When `fibre_length > fibrous_layer.thickness` the fibres are
 drawn as tilted parallelograms.
 """
-function BiophysicalGeometry.draw_insulation_schematic!(ax, fur::Fur;
-        fibre_length = fur.thickness)
+function BiophysicalGeometry.draw_insulation_schematic!(ax, fibrous_layer::FibrousLayer;
+        fibre_length = fibrous_layer.thickness)
 
-    thick_mm     = ustrip(u"mm", fur.thickness)
+    thick_mm     = ustrip(u"mm", fibrous_layer.thickness)
     fibre_len_mm = ustrip(u"mm", fibre_length)
-    d_μm         = ustrip(u"μm", fur.fibre_diameter)
-    n_cm2        = ustrip(u"cm^-2", fur.fibre_density)
+    d_μm         = ustrip(u"μm", fibrous_layer.fibre_diameter)
+    n_cm2        = ustrip(u"cm^-2", fibrous_layer.fibre_density)
 
     spacing_mm = 1.0 / sqrt(n_cm2 / 100.0)
     d_display  = spacing_mm * 0.40
@@ -460,7 +460,7 @@ function BiophysicalGeometry.draw_insulation_schematic!(ax, fur::Fur;
     scatter!(ax, [x_ann, x_ann], [0.0, thick_mm];
              color=:black, markersize=6, marker=:rect)
     text!(ax, x_ann + 0.04*W, thick_mm / 2;
-          text="fur depth\n$(round(Int, thick_mm)) mm",
+          text="fibrous layer depth\n$(round(Int, thick_mm)) mm",
           fontsize=9, align=(:left, :center))
 
     if dx > 1e-6
@@ -495,7 +495,7 @@ function BiophysicalGeometry.draw_insulation_schematic!(ax, fur::Fur;
           text="spacing ≈ $(round(spacing_mm, digits=2)) mm  (N = $n_cm2 cm⁻²)",
           fontsize=8, align=(:center, :bottom), color=:darkgreen)
 
-    ax.title  = "Fur schematic  (fibre width exaggerated for clarity)"
+    ax.title  = "Fibrous layer schematic  (fibre width exaggerated for clarity)"
     ax.xlabel = "position (mm)"
     ax.ylabel = "height above skin (mm)"
     ylims!(ax, -skin_h * 5, thick_mm * 1.55)
@@ -504,13 +504,13 @@ function BiophysicalGeometry.draw_insulation_schematic!(ax, fur::Fur;
 end
 
 """
-    draw_insulation_coverage!(ax, fur::Fur; d_range=LinRange(10,120,200), N_range=LinRange(200,9000,200))
+    draw_insulation_coverage!(ax, fibrous_layer::FibrousLayer; d_range=LinRange(10,120,200), N_range=LinRange(200,9000,200))
 
 Draw a coverage-fraction heatmap (plasma colormap) with contour lines at f = 0.25,
-0.50, 0.75, 1.0, and mark the reference point for `fur`.  Returns the `Heatmap`
+0.50, 0.75, 1.0, and mark the reference point for `fibrous_layer`.  Returns the `Heatmap`
 object so the caller can attach a `Colorbar`.
 """
-function BiophysicalGeometry.draw_insulation_coverage!(ax, fur::Fur;
+function BiophysicalGeometry.draw_insulation_coverage!(ax, fibrous_layer::FibrousLayer;
         d_range = LinRange(10.0, 120.0, 200),
         N_range = LinRange(200.0, 9000.0, 200))
 
@@ -531,8 +531,8 @@ function BiophysicalGeometry.draw_insulation_coverage!(ax, fur::Fur;
         end
     end
 
-    d_ref   = ustrip(u"μm",    fur.fibre_diameter)
-    N_ref   = ustrip(u"cm^-2", fur.fibre_density)
+    d_ref   = ustrip(u"μm",    fibrous_layer.fibre_diameter)
+    N_ref   = ustrip(u"cm^-2", fibrous_layer.fibre_density)
     cov_ref = π * ((d_ref * 1e-6) / 2)^2 * (N_ref * 1e4)
     scatter!(ax, [d_ref], [N_ref]; color=:lime, markersize=11,
              strokecolor=:black, strokewidth=1)
@@ -547,25 +547,25 @@ function BiophysicalGeometry.draw_insulation_coverage!(ax, fur::Fur;
 end
 
 """
-    plot_insulation_properties(fur::Fur; fibre_length=fur.thickness, kwargs...) → Figure
+    plot_insulation_properties(fibrous_layer::FibrousLayer; fibre_length=fibrous_layer.thickness, kwargs...) → Figure
 
-Create a two-panel `Figure` showing a fur schematic and coverage heatmap for
-the supplied `Fur` object.  `fibre_length` may exceed `fur.thickness` to show
-tilted fibres.  `d_range` and `N_range` control the heatmap axes (μm / cm⁻²).
+Create a two-panel `Figure` showing a fibrous layer schematic and coverage heatmap for
+the supplied [`FibrousLayer`](@ref).  `fibre_length` may exceed `fibrous_layer.thickness`
+to show tilted fibres.  `d_range` and `N_range` control the heatmap axes (μm / cm⁻²).
 """
-function BiophysicalGeometry.plot_insulation_properties(fur::Fur;
-        fibre_length = fur.thickness,
+function BiophysicalGeometry.plot_insulation_properties(fibrous_layer::FibrousLayer;
+        fibre_length = fibrous_layer.thickness,
         d_range      = LinRange(10.0, 120.0, 200),
         N_range      = LinRange(200.0, 9000.0, 200))
 
     fig = Figure(size=(900, 420), backgroundcolor=:white)
     Label(fig[0, 1:3],
-          "BiophysicalGeometry.jl — Fur Properties";
+          "BiophysicalGeometry.jl — FibrousLayer Properties";
           fontsize=14, font=:bold, padding=(0, 0, 8, 0))
     ax1 = Axis(fig[1, 1])
     ax2 = Axis(fig[1, 2])
-    draw_insulation_schematic!(ax1, fur; fibre_length)
-    hm = draw_insulation_coverage!(ax2, fur; d_range, N_range)
+    draw_insulation_schematic!(ax1, fibrous_layer; fibre_length)
+    hm = draw_insulation_coverage!(ax2, fibrous_layer; d_range, N_range)
     Colorbar(fig[1, 3], hm; label="Coverage fraction f", width=14, labelsize=10)
     colgap!(fig.layout, 12)
     colsize!(fig.layout, 3, Auto(0.05))

--- a/src/BiophysicalGeometry.jl
+++ b/src/BiophysicalGeometry.jl
@@ -4,7 +4,8 @@ using Unitful
 
 export AbstractGeometryModel, AbstractGeometryPars, AbstractBody, Body
 export AbstractShape, Cylinder, Sphere, Ellipsoid, Plate, LeopardFrog, DesertIguana
-export AbstractInsulation, CompositeInsulation, Naked, Fur, Fat
+export AbstractInsulationLayer, AbstractSolidLayer, AbstractPorousLayer
+export CompositeInsulation, Naked, FibrousLayer, FatLayer
 export SolarOrientation, Intermediate, ParallelToSun, NormalToSun
 export SurfaceAreas
 

--- a/src/BiophysicalGeometry.jl
+++ b/src/BiophysicalGeometry.jl
@@ -9,7 +9,7 @@ export SurfaceAreas
 export geometry, shape, insulation
 export total_area, skin_area, evaporation_area, skin_radius, insulation_radius, flesh_radius, flesh_volume
 export surface_area, silhouette_area, SolarOrientation, Intermediate, ParallelToSun, NormalToSun, ZenithAngleVarying
-export CharDimFormula, VolumeCubeRoot, ShortestDimension
+export outer_insulation
 
 include("geometry.jl")
 include("shapes/plate.jl")

--- a/src/BiophysicalGeometry.jl
+++ b/src/BiophysicalGeometry.jl
@@ -10,10 +10,8 @@ export SurfaceAreas
 
 export geometry, shape, insulation
 export total_area, skin_area, evaporation_area, skin_radius, insulation_radius, flesh_radius, flesh_volume
-export surface_area, silhouette_area, SolarOrientation, Intermediate, ParallelToSun, NormalToSun, ZenithAngleVarying
-<<<<<<< characteristic-dimension-options
+export surface_area, silhouette_area, ZenithAngleVarying
 export outer_insulation
-=======
 export plot_body, draw_cutaway!, plot_cross_sections, draw_cross_sections!
 export draw_insulation_schematic!, draw_insulation_coverage!, plot_insulation_properties
 
@@ -40,7 +38,6 @@ end
 function plot_insulation_properties(args...; kwargs...)
     error("plot_insulation_properties requires a Makie backend — add `using GLMakie` (or CairoMakie / WGLMakie) first.")
 end
->>>>>>> main
 
 include("geometry.jl")
 include("shapes/plate.jl")

--- a/src/BiophysicalGeometry.jl
+++ b/src/BiophysicalGeometry.jl
@@ -9,6 +9,7 @@ export SurfaceAreas
 export geometry, shape, insulation
 export total_area, skin_area, evaporation_area, skin_radius, insulation_radius, flesh_radius, flesh_volume
 export surface_area, silhouette_area, SolarOrientation, Intermediate, ParallelToSun, NormalToSun, ZenithAngleVarying
+export CharDimFormula, VolumeCubeRoot, ShortestDimension
 
 include("geometry.jl")
 include("shapes/plate.jl")

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -9,72 +9,76 @@ Abstract supertype for the shape of the organism being modelled.
 abstract type AbstractShape <: AbstractGeometryModel end
 
 """
-    AbstractInsulation
+    AbstractInsulationLayer
 
-Abstract supertype for the insulation of the organism being modelled.
+Abstract supertype for all insulation layers of an organism being modelled.
 """
-abstract type AbstractInsulation <: AbstractGeometryModel end
+abstract type AbstractInsulationLayer end
 
 """
-    Naked <: AbstractInsulation
+    AbstractSolidLayer <: AbstractInsulationLayer
+
+Abstract supertype for solid (non-porous) insulation layers such as subcutaneous fat,
+chitin (arthropod cuticle), or keratin (scales, scutes). Users may define additional
+solid layers by subtyping this.
+"""
+abstract type AbstractSolidLayer <: AbstractInsulationLayer end
+
+"""
+    AbstractPorousLayer <: AbstractInsulationLayer
+
+Abstract supertype for porous (fibre/air-filled) insulation layers such as fur, feathers,
+or hair. The porous structure is characterised by fibre geometry rather than bulk
+fraction. Users may define additional porous layers by subtyping this.
+"""
+abstract type AbstractPorousLayer <: AbstractInsulationLayer end
+
+"""
+    Naked <: AbstractInsulationLayer
 
     Naked()
 
-Insulation trait for an organism without fur.
+Insulation trait for an organism without any insulation layer.
 """
-struct Naked <: AbstractInsulation end
+struct Naked <: AbstractInsulationLayer end
 
 """
-    Fur <: AbstractInsulation
+    FibrousLayer <: AbstractPorousLayer
 
-    Fur(thickness, fibre_diameter, fibre_density)
+    FibrousLayer(thickness, fibre_diameter, fibre_density)
 
-Insulation trait for an organism with fur.
+A porous insulation layer characterised by fibre geometry (fur, feathers, wool, hair, etc.).
 """
-struct Fur{T,D,R} <: AbstractInsulation
+struct FibrousLayer{T,D,R} <: AbstractPorousLayer
     thickness::T
     fibre_diameter::D
     fibre_density::R
 end
 
-# TODO
-# """
-#     Feathers <: AbstractInsulation
-#
-#     Feathers(thickness)
-#
-# Insulation trait for an organism with feathers.
-# """
-# struct Feathers{T,D,R} <: AbstractInsulation
-#     thickness::T
-#     fibre_diameter::D
-#     fibre_density::R
-# end
-
 """
-    Fat <: AbstractInsulation
+    FatLayer <: AbstractSolidLayer
 
-    Fat(fraction, density)
+    FatLayer(fraction, density)
 
-Insulation trait for an organism with fat.
+A solid insulation layer of subcutaneous fat.
 """
-struct Fat{F,D} <: AbstractInsulation
+struct FatLayer{F,D} <: AbstractSolidLayer
     fraction::F
     density::D
 end
 
 """
-    CompositeInsulation <: AbstractInsulation
+    CompositeInsulation <: AbstractInsulationLayer
 
     CompositeInsulation(layers)
 
-A composite of insulation layers (e.g., fur, fat) for an organism.
+A composite of insulation layers (e.g., fibrous layer over fat layer) for an organism.
 """
-struct CompositeInsulation{T<:Tuple} <: AbstractInsulation
+struct CompositeInsulation{T<:Tuple} <: AbstractInsulationLayer
     layers::T
 end
-CompositeInsulation(i::AbstractInsulation) = CompositeInsulation((i,))
-CompositeInsulation(is::AbstractInsulation...) = CompositeInsulation((is...,))
+CompositeInsulation(i::AbstractInsulationLayer) = CompositeInsulation((i,))
+CompositeInsulation(is::AbstractInsulationLayer...) = CompositeInsulation((is...,))
 
 geometry(shape, ins::CompositeInsulation) = geometry(shape, ins.layers...)
 
@@ -162,18 +166,18 @@ abstract type AbstractBody <: AbstractGeometryPars end
 """
     Body <: AbstractBody
 
-    Body(shape::AbstractShape, insulation::AbstractInsulation)
-    Body(shape::AbstractShape, insulation::AbstractInsulation, geometry::AbstractGeometryPars)
+    Body(shape::AbstractShape, insulation::AbstractInsulationLayer)
+    Body(shape::AbstractShape, insulation::AbstractInsulationLayer, geometry::AbstractGeometryPars)
 
 Physical dimensions of a body or body part that may or may not be insulated.
 """
-struct Body{S<:AbstractShape, I<:AbstractInsulation, G<:AbstractGeometryPars} <: AbstractBody
+struct Body{S<:AbstractShape, I<:AbstractInsulationLayer, G<:AbstractGeometryPars} <: AbstractBody
     shape::S
     insulation::I
     geometry::G
 end
 
-Body(shape::AbstractShape, insulation::AbstractInsulation) =
+Body(shape::AbstractShape, insulation::AbstractInsulationLayer) =
     Body(shape, insulation, geometry(shape, insulation))
 
 """
@@ -184,7 +188,7 @@ Return the shape of `body`.
 shape(body::AbstractBody) = body.shape
 
 """
-    insulation(body::AbstractBody) -> AbstractInsulation
+    insulation(body::AbstractBody) -> AbstractInsulationLayer
 
 Return the insulation of `body`.
 """
@@ -228,9 +232,9 @@ Return the area available for evaporative water loss from `body`.
 evaporation_area(body::AbstractBody) = evaporation_area(shape(body), insulation(body), body)
 
 # Fallbacks — mostly the same for all shapes
-total_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.total
-skin_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.skin
-evaporation_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.convection
+total_area(shape::AbstractShape, insulation::AbstractInsulationLayer, body::AbstractBody) = body.geometry.area.total
+skin_area(shape::AbstractShape, insulation::AbstractInsulationLayer, body::AbstractBody) = body.geometry.area.skin
+evaporation_area(shape::AbstractShape, insulation::AbstractInsulationLayer, body::AbstractBody) = body.geometry.area.convection
 
 # CompositeInsulation uses the outer layer
 total_area(shape::AbstractShape, ins::CompositeInsulation, body::AbstractBody) =
@@ -260,15 +264,15 @@ end
 Return the volume of the flesh (non-fat) component of `body`.
 """
 flesh_volume(body::AbstractBody) = flesh_volume(insulation(body), body)
-function flesh_volume(ins::Union{Fat, CompositeInsulation}, body)
-    fat = inner_insulation(body.insulation)
+function flesh_volume(ins::Union{FatLayer, CompositeInsulation}, body)
+    fat_layer = inner_insulation(body.insulation)
     if body.geometry.length.fat > zero(body.geometry.length.fat)
-        body.geometry.volume - body.shape.mass * fat.fraction / fat.density
+        body.geometry.volume - body.shape.mass * fat_layer.fraction / fat_layer.density
     else
         body.geometry.volume
     end
 end
-flesh_volume(ins::Fur, body) = body.geometry.volume
+flesh_volume(ins::FibrousLayer, body) = body.geometry.volume
 flesh_volume(ins::Naked, body) = body.geometry.volume
 
 # Radius
@@ -297,32 +301,34 @@ flesh_radius(body::AbstractBody) = flesh_radius(shape(body), insulation(body), b
 # Helpers for handling CompositeInsulation
 
 """
-    outer_insulation(ins::AbstractInsulation) -> AbstractInsulation
+    outer_insulation(ins::AbstractInsulationLayer) -> AbstractInsulationLayer
 
 Return the outermost insulation layer. For [`CompositeInsulation`](@ref), returns the
-fur layer if one is present, otherwise the last layer. For other types, returns `ins` itself.
+porous layer (e.g. [`FibrousLayer`](@ref)) if one is present, otherwise the last layer.
+For other types, returns `ins` itself.
 """
-outer_insulation(ins::AbstractInsulation) = ins
+outer_insulation(ins::AbstractInsulationLayer) = ins
 function outer_insulation(ins::CompositeInsulation)
-    fur_layer = findlast(i -> i isa Fur, ins.layers)
-    if fur_layer !== nothing
-        ins.layers[fur_layer]
+    idx = findlast(i -> i isa AbstractPorousLayer, ins.layers)
+    if idx !== nothing
+        ins.layers[idx]
     else
         ins.layers[end]
     end
 end
 
 """
-    inner_insulation(ins::AbstractInsulation) -> AbstractInsulation
+    inner_insulation(ins::AbstractInsulationLayer) -> AbstractInsulationLayer
 
 Return the innermost insulation layer. For [`CompositeInsulation`](@ref), returns the
-fat layer if one is present, otherwise the last layer. For other types, returns `ins` itself.
+solid layer (e.g. [`FatLayer`](@ref)) if one is present, otherwise the last layer.
+For other types, returns `ins` itself.
 """
-inner_insulation(ins::AbstractInsulation) = ins
+inner_insulation(ins::AbstractInsulationLayer) = ins
 function inner_insulation(ins::CompositeInsulation)
-    fat_layer = findfirst(i -> i isa Fat, ins.layers)
-    if fat_layer !== nothing
-        ins.layers[fat_layer]
+    idx = findfirst(i -> i isa AbstractSolidLayer, ins.layers)
+    if idx !== nothing
+        ins.layers[idx]
     else
         ins.layers[end]
     end

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -26,8 +26,8 @@ struct Naked <: AbstractInsulation end
 
 """
     Fur <: AbstractInsulation
-    
-    Fur(thickness)
+
+    Fur(thickness, fibre_diameter, fibre_density)
 
 Insulation trait for an organism with fur.
 """
@@ -40,9 +40,9 @@ end
 # TODO
 # """
 #     Feathers <: AbstractInsulation
-    
+#
 #     Feathers(thickness)
-
+#
 # Insulation trait for an organism with feathers.
 # """
 # struct Feathers{T,D,R} <: AbstractInsulation
@@ -53,7 +53,7 @@ end
 
 """
     Fat <: AbstractInsulation
-    
+
     Fat(fraction, density)
 
 Insulation trait for an organism with fat.
@@ -101,11 +101,43 @@ Surface areas of an organism for heat exchange calculations.
     ventral::V = nothing
 end
 
+"""
+    SolarOrientation
+
+Abstract supertype for solar orientation traits used to select how silhouette area is computed.
+
+Concrete subtypes: [`NormalToSun`](@ref), [`ParallelToSun`](@ref), [`Intermediate`](@ref), [`ZenithAngleVarying`](@ref).
+"""
 abstract type SolarOrientation <: AbstractGeometryPars end
 
+"""
+    NormalToSun <: SolarOrientation
+
+Orientation trait: body axis perpendicular to the sun, maximising silhouette area.
+"""
 struct NormalToSun <: SolarOrientation end
+
+"""
+    ParallelToSun <: SolarOrientation
+
+Orientation trait: body axis parallel to the sun, minimising silhouette area.
+"""
 struct ParallelToSun <: SolarOrientation end
+
+"""
+    Intermediate <: SolarOrientation
+
+Orientation trait: silhouette area is the average of [`NormalToSun`](@ref) and [`ParallelToSun`](@ref).
+"""
 struct Intermediate <: SolarOrientation end
+
+"""
+    ZenithAngleVarying <: SolarOrientation
+
+Orientation trait: silhouette area computed from the solar zenith angle via shape-specific dispatch.
+Falls back to [`Intermediate`](@ref) for shapes that do not implement zenith-angle silhouette area.
+"""
+struct ZenithAngleVarying <: SolarOrientation end
 
 """
     Geometry
@@ -127,18 +159,13 @@ Abstract supertype for organism bodies.
 """
 abstract type AbstractBody <: AbstractGeometryPars end
 
-shape(body::AbstractBody) = body.shape
-insulation(body::AbstractBody) = body.insulation
-geometry(body::AbstractBody) = body.geometry
-surface_area(body::AbstractBody) = surface_area(shape(body), body)
-
 """
     Body <: AbstractBody
 
     Body(shape::AbstractShape, insulation::AbstractInsulation)
     Body(shape::AbstractShape, insulation::AbstractInsulation, geometry::AbstractGeometryPars)
 
-Physical dimensions of a body or body part that may or may note be insulated.
+Physical dimensions of a body or body part that may or may not be insulated.
 """
 struct Body{S<:AbstractShape, I<:AbstractInsulation, G<:AbstractGeometryPars} <: AbstractBody
     shape::S
@@ -146,30 +173,61 @@ struct Body{S<:AbstractShape, I<:AbstractInsulation, G<:AbstractGeometryPars} <:
     geometry::G
 end
 
-abstract type SolarOrientation <: AbstractGeometryPars end
-
-struct NormalToSun <: SolarOrientation end
-struct ParallelToSun <: SolarOrientation end
-struct Intermediate <: SolarOrientation end
-struct ZenithAngleVarying <: SolarOrientation end
-
-# constructors and functions
-
-shape(body::AbstractBody) = body.shape
-insulation(body::AbstractBody) = body.insulation
-geometry(body::AbstractBody) = body.geometry
-surface_area(body::AbstractBody) = surface_area(shape(body), body)
-
 Body(shape::AbstractShape, insulation::AbstractInsulation) =
     Body(shape, insulation, geometry(shape, insulation))
 
+"""
+    shape(body::AbstractBody) -> AbstractShape
+
+Return the shape of `body`.
+"""
+shape(body::AbstractBody) = body.shape
+
+"""
+    insulation(body::AbstractBody) -> AbstractInsulation
+
+Return the insulation of `body`.
+"""
+insulation(body::AbstractBody) = body.insulation
+
+"""
+    geometry(body::AbstractBody) -> AbstractGeometryPars
+
+Return the geometry of `body`.
+"""
+geometry(body::AbstractBody) = body.geometry
+
+"""
+    surface_area(body::AbstractBody)
+
+Return the outer surface area of `body`.
+"""
+surface_area(body::AbstractBody) = surface_area(shape(body), body)
+
 # Surface areas
 
+"""
+    total_area(body::AbstractBody)
+
+Return the total outer surface area of `body` (including insulation if present).
+"""
 total_area(body::AbstractBody) = total_area(shape(body), insulation(body), body)
+
+"""
+    skin_area(body::AbstractBody)
+
+Return the skin surface area of `body` (beneath any insulation).
+"""
 skin_area(body::AbstractBody) = skin_area(shape(body), insulation(body), body)
+
+"""
+    evaporation_area(body::AbstractBody)
+
+Return the area available for evaporative water loss from `body`.
+"""
 evaporation_area(body::AbstractBody) = evaporation_area(shape(body), insulation(body), body)
 
-# Fallbacks - mostly these are the same for all shapes
+# Fallbacks — mostly the same for all shapes
 total_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.total
 skin_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.skin
 evaporation_area(shape::AbstractShape, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.area.convection
@@ -182,33 +240,25 @@ skin_area(shape::AbstractShape, ins::CompositeInsulation, body::AbstractBody) =
 evaporation_area(shape::AbstractShape, ins::CompositeInsulation, body::AbstractBody) =
     evaporation_area(shape, outer_insulation(ins), body)
 
-# Silhouette area
-
-"""
-    silhouette_area(body::AbstractBody, θ)
-    silhouette_area(body::AbstractBody, orientation::SolarOrientation)
-
-Calculates the silhouette (projected) area of an object given a
-solar zenith angle `θ` or a fixed [`SolarOrientation`](@ref) such as
-[`NormalToSun`](@ref), [`ParallelToSun`](@ref), or [`Intermediate`](@ref).
-"""
-silhouette_area(body::AbstractBody, θ) = silhouette_area(shape(body), insulation(body), body, θ)
-silhouette_area(body::AbstractBody) = silhouette_area(shape(body), insulation(body), body)
-# Orientation-specific implementations
-silhouette_area(body::AbstractBody, ::NormalToSun) = silhouette_area(body).normal
-silhouette_area(body::AbstractBody, ::ParallelToSun) = silhouette_area(body).parallel
-silhouette_area(body::AbstractBody, ::Intermediate) =
-    (silhouette_area(body).normal + silhouette_area(body).parallel) * 0.5
-
 # Insulation area
 
-# TODO make this 'insulation_area'
-function hair_area(fibre_diameter, fibre_density, skin)
+"""
+    insulation_area(fibre_diameter, fibre_density, skin)
+
+Return the total cross-sectional area of insulation fibres (fur/feather) covering `skin` area,
+given `fibre_diameter` and `fibre_density` (fibres per unit area).
+"""
+function insulation_area(fibre_diameter, fibre_density, skin)
     π * (fibre_diameter / 2) ^ 2 * (fibre_density * skin)
 end
 
 # Volume
 
+"""
+    flesh_volume(body::AbstractBody)
+
+Return the volume of the flesh (non-fat) component of `body`.
+"""
 flesh_volume(body::AbstractBody) = flesh_volume(insulation(body), body)
 function flesh_volume(ins::Union{Fat, CompositeInsulation}, body)
     fat = inner_insulation(body.insulation)
@@ -223,89 +273,98 @@ flesh_volume(ins::Naked, body) = body.geometry.volume
 
 # Radius
 
-skin_radius(body::AbstractBody) = skin_radius(shape(body), insulation(body), body)
-insulation_radius(body::AbstractBody) = insulation_radius(shape(body), insulation(body), body)
-flesh_radius(body::AbstractBody) = flesh_radius(shape(body), insulation(body), body)
+"""
+    skin_radius(body::AbstractBody)
 
+Return the radius at the skin surface of `body`.
+"""
+skin_radius(body::AbstractBody) = skin_radius(shape(body), insulation(body), body)
+
+"""
+    insulation_radius(body::AbstractBody)
+
+Return the outer radius of the insulation layer of `body`.
+"""
+insulation_radius(body::AbstractBody) = insulation_radius(shape(body), insulation(body), body)
+
+"""
+    flesh_radius(body::AbstractBody)
+
+Return the radius of the flesh (inner) cylinder of `body`.
+"""
+flesh_radius(body::AbstractBody) = flesh_radius(shape(body), insulation(body), body)
 
 # Helpers for handling CompositeInsulation
 
-# for composite insulation cases (fat and fur/feathers)
+"""
+    outer_insulation(ins::AbstractInsulation) -> AbstractInsulation
+
+Return the outermost insulation layer. For [`CompositeInsulation`](@ref), returns the
+fur layer if one is present, otherwise the last layer. For other types, returns `ins` itself.
+"""
 outer_insulation(ins::AbstractInsulation) = ins
 function outer_insulation(ins::CompositeInsulation)
-    # find fur layer if present
     fur_layer = findlast(i -> i isa Fur, ins.layers)
     if fur_layer !== nothing
         ins.layers[fur_layer]
     else
-        # otherwise the last layer
         ins.layers[end]
     end
 end
 
+"""
+    inner_insulation(ins::AbstractInsulation) -> AbstractInsulation
+
+Return the innermost insulation layer. For [`CompositeInsulation`](@ref), returns the
+fat layer if one is present, otherwise the last layer. For other types, returns `ins` itself.
+"""
 inner_insulation(ins::AbstractInsulation) = ins
 function inner_insulation(ins::CompositeInsulation)
-    # find fur layer if present
     fat_layer = findfirst(i -> i isa Fat, ins.layers)
     if fat_layer !== nothing
         ins.layers[fat_layer]
     else
-        # otherwise the last layer
         ins.layers[end]
     end
 end
 
-flesh_volume(body::AbstractBody) = flesh_volume(insulation(body), body)
-flesh_volume(ins::Union{Fat, CompositeInsulation}, body) = begin
-    fat = inner_insulation(body.insulation)
-    if body.geometry.length.fat > 0.0u"m"
-        body.geometry.volume - body.shape.mass * fat.fraction / fat.density
-    else
-        body.geometry.volume
-    end
-end
-flesh_volume(ins::Fur, body) = body.geometry.volume
-flesh_volume(ins::Naked, body) = body.geometry.volume
-
-# functions to get the appropriate radii
-skin_radius(body::AbstractBody) = skin_radius(shape(body), insulation(body), body)
-insulation_radius(body::AbstractBody) = insulation_radius(shape(body), insulation(body), body)
-flesh_radius(body::AbstractBody) = flesh_radius(shape(body), insulation(body), body)
-
-# functions to compute silhouette area as a function of zenith angle (passive) or 
-# orientation (thermoregulating)
+# Silhouette area
 
 """
     silhouette_area(body::AbstractBody, θ)
 
-Calculates the silhouette (projected) area of an object given a solar zenith angle, θ.
-
+Return the silhouette (projected) area of `body` at solar zenith angle `θ`.
 """
 silhouette_area(body::AbstractBody, θ) = silhouette_area(shape(body), insulation(body), body, θ)
 
 """
-    silhouette_area(body::AbstractBody, orientation)
+    silhouette_area(body::AbstractBody) -> NamedTuple
 
-Calculates the silhouette (projected) area of an object given an orientation towards the sun (normal, parallel or inbetween).
-
+Return a named tuple `(normal=..., parallel=...)` of silhouette areas for the two
+bounding orientations of `body` relative to the sun.
 """
 silhouette_area(body::AbstractBody) = silhouette_area(shape(body), insulation(body), body)
 
-# Orientation-specific implementations
-silhouette_area(body::AbstractBody, ::NormalToSun) =
-    silhouette_area(body).normal
+"""
+    silhouette_area(body::AbstractBody, orientation::SolarOrientation)
+    silhouette_area(body::AbstractBody, orientation::SolarOrientation, zenith_angle)
 
-silhouette_area(body::AbstractBody, ::ParallelToSun) =
-    silhouette_area(body).parallel
+Return the silhouette (projected) area of `body` for a given [`SolarOrientation`](@ref)
+or a zenith angle paired with an orientation trait.
 
+- [`NormalToSun`](@ref): body perpendicular to sun (maximum silhouette area)
+- [`ParallelToSun`](@ref): body parallel to sun (minimum silhouette area)
+- [`Intermediate`](@ref): mean of normal and parallel areas
+- [`ZenithAngleVarying`](@ref): computed from `zenith_angle` via shape-specific dispatch;
+  falls back to [`Intermediate`](@ref) if the shape does not implement zenith-angle silhouette area
+"""
+silhouette_area(body::AbstractBody, ::NormalToSun) = silhouette_area(body).normal
+silhouette_area(body::AbstractBody, ::ParallelToSun) = silhouette_area(body).parallel
 silhouette_area(body::AbstractBody, ::Intermediate) =
     (silhouette_area(body).normal + silhouette_area(body).parallel) * 0.5
 
-# Generic 3-arg fallback: zenith angle ignored for fixed orientations
-silhouette_area(body::AbstractBody, o::SolarOrientation, zenith_angle) = silhouette_area(body, o)
+silhouette_area(body::AbstractBody, o::SolarOrientation, ::Any) = silhouette_area(body, o)
 
-# ZenithAngleVarying: compute from zenith angle using shape-specific 4-arg dispatch;
-# falls back to Intermediate() for shapes that don't implement silhouette_area(shape, ins, body, θ)
 function silhouette_area(body::AbstractBody, ::ZenithAngleVarying, zenith_angle)
     sh  = shape(body)
     ins = insulation(body)
@@ -315,8 +374,3 @@ function silhouette_area(body::AbstractBody, ::ZenithAngleVarying, zenith_angle)
     end
     return silhouette_area(body, Intermediate())
 end
-
-function insulation_area(fibre_diameter, fibre_density, skin)
-    π * (fibre_diameter / 2) ^ 2 * (fibre_density * skin)
-end
-

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -146,10 +146,52 @@ struct ParallelToSun <: SolarOrientation end
 struct Intermediate <: SolarOrientation end
 struct ZenithAngleVarying <: SolarOrientation end
 
+# Characteristic dimension formulas
+
+"""
+    CharDimFormula
+
+Abstract supertype for characteristic dimension formulas used in heat-exchange calculations.
+"""
+abstract type CharDimFormula end
+
+"""
+    VolumeCubeRoot <: CharDimFormula
+
+    VolumeCubeRoot()
+
+Use `V^(1/3)` as the characteristic dimension (default). Orientation-independent and
+scales correctly with body size, but detached from actual linear geometry.
+"""
+struct VolumeCubeRoot <: CharDimFormula end
+
+"""
+    ShortestDimension <: CharDimFormula
+
+    ShortestDimension(factor=1.0)
+
+Use `factor × L_min` as the characteristic dimension, where `L_min` is the shortest
+outer linear dimension of the shape (including insulation/fur if present).
+
+This is physically motivated by boundary-layer theory: the shortest dimension sets
+the minimum fetch length for convection. A factor < 1 is appropriate for flat objects
+like leaves (e.g. `factor=0.7` following Gates 1980).
+
+# Arguments
+- `factor`: multiplier applied to the shortest dimension (default `1.0`)
+"""
+struct ShortestDimension{F} <: CharDimFormula
+    factor::F
+end
+ShortestDimension() = ShortestDimension(1.0)
+
 # constructors and functions
 
-function Body(shape::AbstractShape, insulation::AbstractInsulation)
-    Body(shape, insulation, geometry(shape, insulation))
+function Body(shape::AbstractShape, insulation::AbstractInsulation;
+              characteristic_dimension::CharDimFormula = VolumeCubeRoot())
+    geom = geometry(shape, insulation)
+    cd   = _apply_char_dim(characteristic_dimension, shape, insulation, geom)
+    Body(shape, insulation, Geometry(geom.volume, cd, geom.length, geom.area))
 end
 
 shape(body::AbstractBody) = body.shape
@@ -264,3 +306,7 @@ end
 function insulation_area(fibre_diameter, fibre_density, skin)
     π * (fibre_diameter / 2) ^ 2 * (fibre_density * skin)
 end
+
+_apply_char_dim(::VolumeCubeRoot, shape, ins, geom) = geom.characteristic_dimension
+_apply_char_dim(sd::ShortestDimension, shape, ins, geom) =
+    sd.factor * shortest_outer_dim(shape, ins, geom)

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -111,13 +111,12 @@ end
 """
     Geometry
 
-    Geometry(volume, characteristic_dimension, length, area)
+    Geometry(volume, length, area)
 
 The geometry of an organism.
 """
-struct Geometry{V,C,L,A<:SurfaceAreas} <: AbstractGeometryPars
+struct Geometry{V,L,A<:SurfaceAreas} <: AbstractGeometryPars
     volume::V
-    characteristic_dimension::C
     length::L
     area::A
 end
@@ -146,52 +145,11 @@ struct ParallelToSun <: SolarOrientation end
 struct Intermediate <: SolarOrientation end
 struct ZenithAngleVarying <: SolarOrientation end
 
-# Characteristic dimension formulas
-
-"""
-    CharDimFormula
-
-Abstract supertype for characteristic dimension formulas used in heat-exchange calculations.
-"""
-abstract type CharDimFormula end
-
-"""
-    VolumeCubeRoot <: CharDimFormula
-
-    VolumeCubeRoot()
-
-Use `V^(1/3)` as the characteristic dimension (default). Orientation-independent and
-scales correctly with body size, but detached from actual linear geometry.
-"""
-struct VolumeCubeRoot <: CharDimFormula end
-
-"""
-    ShortestDimension <: CharDimFormula
-
-    ShortestDimension(factor=1.0)
-
-Use `factor × L_min` as the characteristic dimension, where `L_min` is the shortest
-outer linear dimension of the shape (including insulation/fur if present).
-
-This is physically motivated by boundary-layer theory: the shortest dimension sets
-the minimum fetch length for convection. A factor < 1 is appropriate for flat objects
-like leaves (e.g. `factor=0.7` following Gates 1980).
-
-# Arguments
-- `factor`: multiplier applied to the shortest dimension (default `1.0`)
-"""
-struct ShortestDimension{F} <: CharDimFormula
-    factor::F
-end
-ShortestDimension() = ShortestDimension(1.0)
-
 # constructors and functions
 
-function Body(shape::AbstractShape, insulation::AbstractInsulation;
-              characteristic_dimension::CharDimFormula = VolumeCubeRoot())
+function Body(shape::AbstractShape, insulation::AbstractInsulation)
     geom = geometry(shape, insulation)
-    cd   = _apply_char_dim(characteristic_dimension, shape, insulation, geom)
-    Body(shape, insulation, Geometry(geom.volume, cd, geom.length, geom.area))
+    Body(shape, insulation, geom)
 end
 
 shape(body::AbstractBody) = body.shape
@@ -307,6 +265,3 @@ function insulation_area(fibre_diameter, fibre_density, skin)
     π * (fibre_diameter / 2) ^ 2 * (fibre_density * skin)
 end
 
-_apply_char_dim(::VolumeCubeRoot, shape, ins, geom) = geom.characteristic_dimension
-_apply_char_dim(sd::ShortestDimension, shape, ins, geom) =
-    sd.factor * shortest_outer_dim(shape, ins, geom)

--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -6,22 +6,22 @@ A cylindrical organism shape.
 struct Cylinder{M,D,B} <: AbstractShape
     mass::M
     density::D
-    b::B
+    aspect_ratio_b::B
 end
 
 function geometry(shape::Cylinder, ::Naked)
     volume = shape.mass / shape.density
-    radius_skin = (volume / (shape.b * π * 2))^(1 / 3)
-    length_skin = shape.b * radius_skin * 2
+    radius_skin = (volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
+    length_skin = shape.aspect_ratio_b * radius_skin * 2
     total = surface_area(shape, radius_skin, length_skin)
     return Geometry(volume, (; length_skin, radius_skin), SurfaceAreas(; total))
 end
 function geometry(shape::Cylinder, fur::Fur)
     volume = shape.mass / shape.density
-    radius_skin = (volume / (shape.b * π * 2))^(1 / 3)
+    radius_skin = (volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
     radius_fur = radius_skin + fur.thickness
-    length_skin = shape.b * radius_skin * 2
-    length_fur = shape.b * radius_skin * 2 + fur.thickness * 2
+    length_skin = shape.aspect_ratio_b * radius_skin * 2
+    length_fur = shape.aspect_ratio_b * radius_skin * 2 + fur.thickness * 2
     total = surface_area(shape, radius_fur, length_fur)
     skin = surface_area(shape, radius_skin, length_skin)
     area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
@@ -33,9 +33,9 @@ function geometry(shape::Cylinder, fat::Fat)
     fat_volume = fat_mass / fat.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    radius_skin = (volume / (shape.b * π * 2))^(1 / 3)
-    length_skin = shape.b * radius_skin * 2
-    radius_flesh = (flesh_volume / (shape.b * π * 2))^(1 / 3)
+    radius_skin = (volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
+    length_skin = shape.aspect_ratio_b * radius_skin * 2
+    radius_flesh = (flesh_volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_skin, length_skin)
     return Geometry(volume, (; radius_skin, length_skin, fat), SurfaceAreas(; total))
@@ -45,11 +45,11 @@ function geometry(shape::Cylinder, fur::Fur, fat::Fat)
     fat_volume = fat_mass / fat.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    radius_skin = (volume / (shape.b * π * 2))^(1 / 3)
+    radius_skin = (volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
     radius_fur = radius_skin + fur.thickness
-    length_skin = shape.b * radius_skin * 2
-    length_fur = shape.b * radius_skin * 2 + fur.thickness * 2
-    radius_flesh = (flesh_volume / (shape.b * π * 2))^(1 / 3)
+    length_skin = shape.aspect_ratio_b * radius_skin * 2
+    length_fur = shape.aspect_ratio_b * radius_skin * 2 + fur.thickness * 2
+    radius_flesh = (flesh_volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_fur, length_fur)
     skin = surface_area(shape, radius_skin, length_skin)

--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -6,54 +6,54 @@ A cylindrical organism shape.
 struct Cylinder{M,D,B} <: AbstractShape
     mass::M
     density::D
-    aspect_ratio_b::B
+    axis_ratio_b::B
 end
 
 function geometry(shape::Cylinder, ::Naked)
     volume = shape.mass / shape.density
-    radius_skin = (volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
-    length_skin = shape.aspect_ratio_b * radius_skin * 2
+    radius_skin = (volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    length_skin = shape.axis_ratio_b * radius_skin * 2
     total = surface_area(shape, radius_skin, length_skin)
     return Geometry(volume, (; length_skin, radius_skin), SurfaceAreas(; total))
 end
-function geometry(shape::Cylinder, fur::Fur)
+function geometry(shape::Cylinder, fibrous_layer::FibrousLayer)
     volume = shape.mass / shape.density
-    radius_skin = (volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
-    radius_fur = radius_skin + fur.thickness
-    length_skin = shape.aspect_ratio_b * radius_skin * 2
-    length_fur = shape.aspect_ratio_b * radius_skin * 2 + fur.thickness * 2
+    radius_skin = (volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    radius_fur = radius_skin + fibrous_layer.thickness
+    length_skin = shape.axis_ratio_b * radius_skin * 2
+    length_fur = shape.axis_ratio_b * radius_skin * 2 + fibrous_layer.thickness * 2
     total = surface_area(shape, radius_fur, length_fur)
     skin = surface_area(shape, radius_skin, length_skin)
-    area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
+    area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
     convection = skin - area_hair
     return Geometry(volume, (; radius_skin, radius_fur, length_skin, length_fur), SurfaceAreas(; total, skin, convection))
 end
-function geometry(shape::Cylinder, fat::Fat)
-    fat_mass = shape.mass * fat.fraction
-    fat_volume = fat_mass / fat.density
+function geometry(shape::Cylinder, fat_layer::FatLayer)
+    fat_mass = shape.mass * fat_layer.fraction
+    fat_volume = fat_mass / fat_layer.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    radius_skin = (volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
-    length_skin = shape.aspect_ratio_b * radius_skin * 2
-    radius_flesh = (flesh_volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
+    radius_skin = (volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    length_skin = shape.axis_ratio_b * radius_skin * 2
+    radius_flesh = (flesh_volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_skin, length_skin)
     return Geometry(volume, (; radius_skin, length_skin, fat), SurfaceAreas(; total))
 end
-function geometry(shape::Cylinder, fur::Fur, fat::Fat)
-    fat_mass = shape.mass * fat.fraction
-    fat_volume = fat_mass / fat.density
+function geometry(shape::Cylinder, fibrous_layer::FibrousLayer, fat_layer::FatLayer)
+    fat_mass = shape.mass * fat_layer.fraction
+    fat_volume = fat_mass / fat_layer.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    radius_skin = (volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
-    radius_fur = radius_skin + fur.thickness
-    length_skin = shape.aspect_ratio_b * radius_skin * 2
-    length_fur = shape.aspect_ratio_b * radius_skin * 2 + fur.thickness * 2
-    radius_flesh = (flesh_volume / (shape.aspect_ratio_b * π * 2))^(1 / 3)
+    radius_skin = (volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    radius_fur = radius_skin + fibrous_layer.thickness
+    length_skin = shape.axis_ratio_b * radius_skin * 2
+    length_fur = shape.axis_ratio_b * radius_skin * 2 + fibrous_layer.thickness * 2
+    radius_flesh = (flesh_volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_fur, length_fur)
     skin = surface_area(shape, radius_skin, length_skin)
-    area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
+    area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
     convection = skin - area_hair
     return Geometry(volume, (; radius_skin, radius_fur, length_skin, length_fur, fat), SurfaceAreas(; total, skin, convection))
 end
@@ -74,17 +74,17 @@ function silhouette_area(shape::Cylinder, ::Naked, body::AbstractBody, θ)
     l = body.geometry.length.length_skin
     return silhouette_area(shape, r, l, θ)
 end
-function silhouette_area(shape::Cylinder, insulation::Fat, body::AbstractBody, θ)
+function silhouette_area(shape::Cylinder, insulation::FatLayer, body::AbstractBody, θ)
     r = body.geometry.length.radius_skin
     l = body.geometry.length.length_skin
     return silhouette_area(shape, r, l, θ)
 end
-function silhouette_area(shape::Cylinder, insulation::Fur, body::AbstractBody, θ)
+function silhouette_area(shape::Cylinder, insulation::FibrousLayer, body::AbstractBody, θ)
     r = body.geometry.length.radius_fur
     l = body.geometry.length.length_fur
     return silhouette_area(shape, r, l, θ)
 end
-function silhouette_area(shape::Cylinder, insulation::Union{Naked,Fat}, body::AbstractBody, θ)
+function silhouette_area(shape::Cylinder, insulation::Union{Naked,FatLayer}, body::AbstractBody, θ)
     r = body.geometry.length.radius_skin
     l = body.geometry.length.length_skin
     return silhouette_area(shape, r, l, θ)
@@ -96,14 +96,14 @@ function silhouette_area(shape::Cylinder, insulation::CompositeInsulation, body:
     return silhouette_area(shape, r, l, θ)
 end
 silhouette_area(shape::Cylinder, r, l, θ) = 2 * r * l * sin(θ) + π * r^2 * cos(θ)
-function silhouette_area(shape::Cylinder, insulation::Union{Naked,Fat}, body::AbstractBody)
+function silhouette_area(shape::Cylinder, insulation::Union{Naked,FatLayer}, body::AbstractBody)
     r = body.geometry.length.radius_skin
     l = body.geometry.length.length_skin
     normal = 2 * r * l
     parallel = π *r^2
     return (; normal, parallel)
 end
-function silhouette_area(shape::Cylinder, insulation::Union{Fur,CompositeInsulation}, body::AbstractBody)
+function silhouette_area(shape::Cylinder, insulation::Union{FibrousLayer,CompositeInsulation}, body::AbstractBody)
     r = body.geometry.length.radius_fur
     l = body.geometry.length.length_fur
     normal = 2 * r * l
@@ -113,19 +113,19 @@ end
 
 # Radius
 
-skin_radius(shape::Cylinder, insulation::AbstractInsulation, body) = body.geometry.length.radius_skin
+skin_radius(shape::Cylinder, insulation::AbstractInsulationLayer, body) = body.geometry.length.radius_skin
 
 # naked
 insulation_radius(shape::Cylinder, insulation::Naked, body) = body.geometry.length.radius_skin
 flesh_radius(shape::Cylinder, insulation::Naked, body) = body.geometry.length.radius_skin
 
 # fur
-insulation_radius(shape::Cylinder, insulation::Fur, body) = body.geometry.length.radius_fur
-flesh_radius(shape::Cylinder, insulation::Fur, body) = body.geometry.length.radius_skin
+insulation_radius(shape::Cylinder, insulation::FibrousLayer, body) = body.geometry.length.radius_fur
+flesh_radius(shape::Cylinder, insulation::FibrousLayer, body) = body.geometry.length.radius_skin
 
 # fat
-insulation_radius(shape::Cylinder, insulation::Fat, body) = body.geometry.length.radius_skin
-flesh_radius(shape::Cylinder, insulation::Fat, body) = body.geometry.length.radius_skin - body.geometry.length.fat
+insulation_radius(shape::Cylinder, insulation::FatLayer, body) = body.geometry.length.radius_skin
+flesh_radius(shape::Cylinder, insulation::FatLayer, body) = body.geometry.length.radius_skin - body.geometry.length.fat
 
 # fur and fat
 insulation_radius(shape::Cylinder, insulation::CompositeInsulation, body) = body.geometry.length.radius_fur

--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -3,7 +3,7 @@
 
 A cylindrical organism shape.
 """
-mutable struct Cylinder{M,D,B} <: AbstractShape
+struct Cylinder{M,D,B} <: AbstractShape
     mass::M
     density::D
     b::B
@@ -121,6 +121,13 @@ function silhouette_area(shape::Cylinder, insulation::Union{Fur,CompositeInsulat
     parallel = π *r^2
     return (; normal, parallel)
 end
+
+# characteristic dimension functions
+
+shortest_outer_dim(::Cylinder, ::Union{Naked,Fat}, geom) =
+    min(2 * geom.length.radius_skin, geom.length.length_skin)
+shortest_outer_dim(::Cylinder, ::Union{Fur,CompositeInsulation}, geom) =
+    min(2 * geom.length.radius_fur, geom.length.length_fur)
 
 # radii functions
 

--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -14,8 +14,7 @@ function geometry(shape::Cylinder, ::Naked)
     radius_skin = (volume / (shape.b * π * 2))^(1 / 3)
     length_skin = shape.b * radius_skin * 2
     total = surface_area(shape, radius_skin, length_skin)
-    characteristic_dimension = volume^(1 / 3) # radius_skin * 2
-    return Geometry(volume, characteristic_dimension, (; length_skin, radius_skin), SurfaceAreas(; total))
+    return Geometry(volume, (; length_skin, radius_skin), SurfaceAreas(; total))
 end
 
 function geometry(shape::Cylinder, fur::Fur)
@@ -28,8 +27,7 @@ function geometry(shape::Cylinder, fur::Fur)
     skin = surface_area(shape, radius_skin, length_skin)
     area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
-    characteristic_dimension = volume^(1 / 3) + fur.thickness #radius_fur * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur, length_skin, length_fur), SurfaceAreas(; total, skin, convection))
+    return Geometry(volume, (; radius_skin, radius_fur, length_skin, length_fur), SurfaceAreas(; total, skin, convection))
 end
 
 function geometry(shape::Cylinder, fat::Fat)
@@ -42,8 +40,7 @@ function geometry(shape::Cylinder, fat::Fat)
     radius_flesh = (flesh_volume / (shape.b * π * 2))^(1 / 3)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_skin, length_skin)
-    characteristic_dimension = volume^(1 / 3) # radius_skin * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin, length_skin, fat), SurfaceAreas(; total))
+    return Geometry(volume, (; radius_skin, length_skin, fat), SurfaceAreas(; total))
 end
 
 function geometry(shape::Cylinder, fur::Fur, fat::Fat)
@@ -61,8 +58,7 @@ function geometry(shape::Cylinder, fur::Fur, fat::Fat)
     skin = surface_area(shape, radius_skin, length_skin)
     area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
-    characteristic_dimension = volume^(1 / 3) + fur.thickness # radius_fur * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur, length_skin, length_fur, fat), SurfaceAreas(; total, skin, convection))
+    return Geometry(volume, (; radius_skin, radius_fur, length_skin, length_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 # function surface_area(shape::Cylinder, body::AbstractBody)

--- a/src/shapes/desert_iguana.jl
+++ b/src/shapes/desert_iguana.jl
@@ -58,16 +58,7 @@ function silhouette_area(shape::DesertIguana, ::Intermediate)
     return (normal + parallel) * 0.5
 end
 
-<<<<<<< characteristic-dimension-options
-# characteristic dimension functions
-
-# Cylinder approximation L=2D=4R, so the shortest dimension is the diameter (2r).
-shortest_outer_dim(::DesertIguana, ::Naked, geom) = 2 * geom.length.r_skin
-
-# radii functions
-=======
 # Radius
->>>>>>> main
 
 skin_radius(shape::DesertIguana, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin
 insulation_radius(shape::DesertIguana, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin

--- a/src/shapes/desert_iguana.jl
+++ b/src/shapes/desert_iguana.jl
@@ -61,6 +61,11 @@ function silhouette_area(shape::DesertIguana, ::Intermediate)
     return (normal + parallel) * 0.5
 end
 
+# characteristic dimension functions
+
+# Cylinder approximation L=2D=4R, so the shortest dimension is the diameter (2r).
+shortest_outer_dim(::DesertIguana, ::Naked, geom) = 2 * geom.length.r_skin
+
 # radii functions
 
 skin_radius(shape::DesertIguana, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin

--- a/src/shapes/desert_iguana.jl
+++ b/src/shapes/desert_iguana.jl
@@ -18,10 +18,9 @@ function geometry(shape::DesertIguana, ::Naked)
     volume = shape.mass / shape.density
     # Cylinder approximation for body dimensions: assume L=2D=4R, so vol=4π R³
     r_skin = (volume / (4 * π)) ^ (1 / 3)
-    characteristic_dimension = volume ^ (1 / 3)
     # Surface areas from allometric functions (Porter and Tracy 1984)
     total, ventral = surface_area(shape)
-    return Geometry(volume, characteristic_dimension, (; r_skin), SurfaceAreas(; total, ventral))
+    return Geometry(volume, (; r_skin), SurfaceAreas(; total, ventral))
 end
 
 # area functions

--- a/src/shapes/ellipsoid.jl
+++ b/src/shapes/ellipsoid.jl
@@ -6,53 +6,53 @@ An ellipsoidal organism shape.
 struct Ellipsoid{M,D,B,C} <: AbstractShape
     mass::M
     density::D
-    aspect_ratio_b::B
-    aspect_ratio_c::C
+    axis_ratio_b::B
+    axis_ratio_c::C
 end
 
 function geometry(shape::Ellipsoid, ::Naked)
     volume = shape.mass / shape.density
-    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.aspect_ratio_b)) ^ (1 / 3)
+    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.axis_ratio_b)) ^ (1 / 3)
     c_semi_minor_skin = b_semi_minor_skin
-    a_semi_major_skin = b_semi_minor_skin * shape.aspect_ratio_b
+    a_semi_major_skin = b_semi_minor_skin * shape.axis_ratio_b
     e = ((ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) ^ (1 / 2)) / ustrip(u"m", a_semi_major_skin)
     total = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", b_semi_minor_skin), e)
     return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin), SurfaceAreas(; total))
 end
-function geometry(shape::Ellipsoid, fur::Fur)
+function geometry(shape::Ellipsoid, fibrous_layer::FibrousLayer)
     volume = shape.mass / shape.density
-    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.aspect_ratio_b)) ^ (1 / 3)
+    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.axis_ratio_b)) ^ (1 / 3)
     c_semi_minor_skin = b_semi_minor_skin
-    a_semi_major_skin = b_semi_minor_skin * shape.aspect_ratio_b
+    a_semi_major_skin = b_semi_minor_skin * shape.axis_ratio_b
     e = ((ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) ^ (1 / 2)) / ustrip(u"m", a_semi_major_skin)
-    a_semi_major_fur = a_semi_major_skin + fur.thickness
-    b_semi_minor_fur = b_semi_minor_skin + fur.thickness
-    c_semi_minor_fur = c_semi_minor_skin + fur.thickness
+    a_semi_major_fur = a_semi_major_skin + fibrous_layer.thickness
+    b_semi_minor_fur = b_semi_minor_skin + fibrous_layer.thickness
+    c_semi_minor_fur = c_semi_minor_skin + fibrous_layer.thickness
     e = ((a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) ^ (1 / 2)) / a_semi_major_skin
     e_fur = ((a_semi_major_fur ^ 2 - c_semi_minor_fur ^ 2) ^ (1 / 2)) / a_semi_major_fur
     total = surface_area(shape, ustrip(u"m", a_semi_major_fur),  ustrip(u"m", b_semi_minor_fur),  ustrip(u"m", c_semi_minor_fur),  e_fur)
     skin = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
-    area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
-    convection = skin - area_hair 
+    area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
+    convection = skin - area_hair
     return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur), SurfaceAreas(; total, skin, convection))
 end
-function geometry(shape::Ellipsoid, fat::Fat)
-    fat_mass = shape.mass * fat.fraction
-    fat_volume = fat_mass / fat.density
+function geometry(shape::Ellipsoid, fat_layer::FatLayer)
+    fat_mass = shape.mass * fat_layer.fraction
+    fat_volume = fat_mass / fat_layer.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.aspect_ratio_b)) ^ (1 / 3)
+    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.axis_ratio_b)) ^ (1 / 3)
     c_flesh = b_flesh # assuming c = b
-    a_flesh = shape.aspect_ratio_b * b_flesh
+    a_flesh = shape.axis_ratio_b * b_flesh
     fat = prolate_fat_layer(
-        ustrip(u"m^3", flesh_volume), 
-        ustrip(u"m^3", fat_volume), 
-        shape.aspect_ratio_b, 
+        ustrip(u"m^3", flesh_volume),
+        ustrip(u"m^3", fat_volume),
+        shape.axis_ratio_b,
         ustrip(u"m", b_flesh))
     if fat <= 0.0u"m"
-        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.aspect_ratio_b)) ^ (1 / 3)
+        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.axis_ratio_b)) ^ (1 / 3)
         c_semi_minor_skin = b_semi_minor_skin # assuming c = b
-        a_semi_major_skin = shape.aspect_ratio_b * b_semi_minor_skin
+        a_semi_major_skin = shape.axis_ratio_b * b_semi_minor_skin
     else
         a_semi_major_skin = a_flesh + fat
         b_semi_minor_skin = b_flesh + fat
@@ -62,39 +62,39 @@ function geometry(shape::Ellipsoid, fat::Fat)
     total = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
     return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, fat), SurfaceAreas(; total))
 end
-function geometry(shape::Ellipsoid, fur::Fur, fat::Fat)
+function geometry(shape::Ellipsoid, fibrous_layer::FibrousLayer, fat_layer::FatLayer)
     # TODO reduce duplication here
-    fat_mass = shape.mass * fat.fraction
-    fat_volume = fat_mass / fat.density
+    fat_mass = shape.mass * fat_layer.fraction
+    fat_volume = fat_mass / fat_layer.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.aspect_ratio_b)) ^ (1 / 3)
+    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.axis_ratio_b)) ^ (1 / 3)
     c_flesh = b_flesh # assuming c = b
-    a_flesh = shape.aspect_ratio_b * b_flesh
+    a_flesh = shape.axis_ratio_b * b_flesh
     fat = prolate_fat_layer(
-        ustrip(u"m^3", flesh_volume), 
-        ustrip(u"m^3", fat_volume), 
-        shape.aspect_ratio_b, 
+        ustrip(u"m^3", flesh_volume),
+        ustrip(u"m^3", fat_volume),
+        shape.axis_ratio_b,
         ustrip(u"m", b_flesh))
     if fat <= 0.0u"m"
-        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.aspect_ratio_b)) ^ (1 / 3)
+        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.axis_ratio_b)) ^ (1 / 3)
         c_semi_minor_skin = b_semi_minor_skin # assuming c = b
-        a_semi_major_skin = shape.aspect_ratio_b * b_semi_minor_skin
+        a_semi_major_skin = shape.axis_ratio_b * b_semi_minor_skin
     else
         a_semi_major_skin = a_flesh + fat
         b_semi_minor_skin = b_flesh + fat
         c_semi_minor_skin = c_flesh + fat
     end
     e = ((a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) ^ (1 / 2)) / a_semi_major_skin
-    a_semi_major_fur = a_semi_major_skin + fur.thickness
-    b_semi_minor_fur = b_semi_minor_skin + fur.thickness
-    c_semi_minor_fur = c_semi_minor_skin + fur.thickness
+    a_semi_major_fur = a_semi_major_skin + fibrous_layer.thickness
+    b_semi_minor_fur = b_semi_minor_skin + fibrous_layer.thickness
+    c_semi_minor_fur = c_semi_minor_skin + fibrous_layer.thickness
     e = ((a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) ^ (1 / 2)) / a_semi_major_skin
     e_fur = ((a_semi_major_fur ^ 2 - c_semi_minor_fur ^ 2) ^ (1 / 2)) / a_semi_major_fur
     total = surface_area(shape, ustrip(u"m", a_semi_major_fur),  ustrip(u"m", b_semi_minor_fur),  ustrip(u"m", c_semi_minor_fur),  e_fur)
     skin = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
-    area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
-    convection = skin - area_hair 
+    area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
+    convection = skin - area_hair
     return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
@@ -103,18 +103,18 @@ end
 function prolate_fat_layer(
     flesh_volume,
     fat_volume,
-    aspect_ratio_b,
+    axis_ratio_b,
     semi_minor_flesh
 )
     # Flesh is approximated as a prolate spheroid:
     # Volume = 4/3 π * A * B * C
-    # C = B, A = aspect_ratio_b * B
-    # → B = ((3 * volume) / (4 * aspect_ratio_b * π))^(1/3)
+    # C = B, A = axis_ratio_b * B
+    # → B = ((3 * volume) / (4 * axis_ratio_b * π))^(1/3)
     # Fat thickness X is root of cubic: A X^3 + B X^2 + C X + D = 0
     A = 1.0
-    B = aspect_ratio_b * semi_minor_flesh + 2 * semi_minor_flesh
-    C = 2 * aspect_ratio_b * semi_minor_flesh^2 + semi_minor_flesh^2
-    D = aspect_ratio_b * semi_minor_flesh^3 - (( (fat_volume + flesh_volume) * 3.0 ) / (4.0 * π))
+    B = axis_ratio_b * semi_minor_flesh + 2 * semi_minor_flesh
+    C = 2 * axis_ratio_b * semi_minor_flesh^2 + semi_minor_flesh^2
+    D = axis_ratio_b * semi_minor_flesh^3 - (( (fat_volume + flesh_volume) * 3.0 ) / (4.0 * π))
 
     # Components of cubic formula
 
@@ -179,7 +179,7 @@ function silhouette_area(shape::Ellipsoid, a, b, c, θ)
     semax2 = 1 / sqrt(b3)
     π * semax1  * semax2
 end
-function silhouette_area(shape::Ellipsoid, insulation::Union{Naked,Fat}, body::AbstractBody)
+function silhouette_area(shape::Ellipsoid, insulation::Union{Naked,FatLayer}, body::AbstractBody)
     a = body.geometry.length.a_semi_major_skin
     b = body.geometry.length.b_semi_minor_skin
     c = body.geometry.length.c_semi_minor_skin
@@ -187,7 +187,7 @@ function silhouette_area(shape::Ellipsoid, insulation::Union{Naked,Fat}, body::A
     parallel = π * b * c
     return (; normal, parallel)
 end
-function silhouette_area(shape::Ellipsoid, insulation::Union{Fur,CompositeInsulation}, body::AbstractBody)
+function silhouette_area(shape::Ellipsoid, insulation::Union{FibrousLayer,CompositeInsulation}, body::AbstractBody)
     a = body.geometry.length.a_semi_major_fur
     b = body.geometry.length.b_semi_minor_fur
     c = body.geometry.length.c_semi_minor_fur
@@ -201,13 +201,13 @@ function silhouette_area(shape::Ellipsoid, ::Naked, body::AbstractBody, θ)
     c = body.geometry.length.c_semi_minor_skin
     return silhouette_area(shape, a, b, c, θ)
 end
-function silhouette_area(shape::Ellipsoid, insulation::Fur, body::AbstractBody, θ)
+function silhouette_area(shape::Ellipsoid, insulation::FibrousLayer, body::AbstractBody, θ)
     a = body.geometry.length.a_semi_major_fur
     b = body.geometry.length.b_semi_minor_fur
     c = body.geometry.length.c_semi_minor_fur
     return silhouette_area(shape, a, b, c, θ)
 end
-function silhouette_area(shape::Ellipsoid, insulation::Fat, body::AbstractBody, θ)
+function silhouette_area(shape::Ellipsoid, insulation::FatLayer, body::AbstractBody, θ)
     a = body.geometry.length.a_semi_major_skin
     b = body.geometry.length.b_semi_minor_skin
     c = body.geometry.length.c_semi_minor_skin
@@ -222,19 +222,19 @@ end
 
 # Radius
 
-skin_radius(shape::Ellipsoid, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
+skin_radius(shape::Ellipsoid, insulation::AbstractInsulationLayer, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 
 # naked
 insulation_radius(shape::Ellipsoid, insulation::Naked, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 flesh_radius(shape::Ellipsoid, insulation::Naked, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 
 # fur
-insulation_radius(shape::Ellipsoid, insulation::Fur, body::AbstractBody) = body.geometry.length.b_semi_minor_fur
-flesh_radius(shape::Ellipsoid, insulation::Fur, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
+insulation_radius(shape::Ellipsoid, insulation::FibrousLayer, body::AbstractBody) = body.geometry.length.b_semi_minor_fur
+flesh_radius(shape::Ellipsoid, insulation::FibrousLayer, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 
 # fat
-insulation_radius(shape::Ellipsoid, insulation::Fat, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
-flesh_radius(shape::Ellipsoid, insulation::Fat, body::AbstractBody) = body.geometry.length.b_semi_minor_skin - body.geometry.length.fat
+insulation_radius(shape::Ellipsoid, insulation::FatLayer, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
+flesh_radius(shape::Ellipsoid, insulation::FatLayer, body::AbstractBody) = body.geometry.length.b_semi_minor_skin - body.geometry.length.fat
 
 # fur and fat
 insulation_radius(shape::Ellipsoid, insulation::CompositeInsulation, body::AbstractBody) = body.geometry.length.b_semi_minor_fur

--- a/src/shapes/ellipsoid.jl
+++ b/src/shapes/ellipsoid.jl
@@ -6,24 +6,24 @@ An ellipsoidal organism shape.
 struct Ellipsoid{M,D,B,C} <: AbstractShape
     mass::M
     density::D
-    b::B
-    c::C
+    aspect_ratio_b::B
+    aspect_ratio_c::C
 end
 
 function geometry(shape::Ellipsoid, ::Naked)
     volume = shape.mass / shape.density
-    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.b)) ^ (1 / 3)
+    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.aspect_ratio_b)) ^ (1 / 3)
     c_semi_minor_skin = b_semi_minor_skin
-    a_semi_major_skin = b_semi_minor_skin * shape.b
+    a_semi_major_skin = b_semi_minor_skin * shape.aspect_ratio_b
     e = ((ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) ^ (1 / 2)) / ustrip(u"m", a_semi_major_skin)
     total = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", b_semi_minor_skin), e)
     return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin), SurfaceAreas(; total))
 end
 function geometry(shape::Ellipsoid, fur::Fur)
     volume = shape.mass / shape.density
-    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.b)) ^ (1 / 3)
+    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.aspect_ratio_b)) ^ (1 / 3)
     c_semi_minor_skin = b_semi_minor_skin
-    a_semi_major_skin = b_semi_minor_skin * shape.b
+    a_semi_major_skin = b_semi_minor_skin * shape.aspect_ratio_b
     e = ((ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) ^ (1 / 2)) / ustrip(u"m", a_semi_major_skin)
     a_semi_major_fur = a_semi_major_skin + fur.thickness
     b_semi_minor_fur = b_semi_minor_skin + fur.thickness
@@ -41,18 +41,18 @@ function geometry(shape::Ellipsoid, fat::Fat)
     fat_volume = fat_mass / fat.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.b)) ^ (1 / 3)
+    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.aspect_ratio_b)) ^ (1 / 3)
     c_flesh = b_flesh # assuming c = b
-    a_flesh = shape.b * b_flesh
+    a_flesh = shape.aspect_ratio_b * b_flesh
     fat = prolate_fat_layer(
         ustrip(u"m^3", flesh_volume), 
         ustrip(u"m^3", fat_volume), 
-        shape.b, 
+        shape.aspect_ratio_b, 
         ustrip(u"m", b_flesh))
     if fat <= 0.0u"m"
-        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.b)) ^ (1 / 3)
+        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.aspect_ratio_b)) ^ (1 / 3)
         c_semi_minor_skin = b_semi_minor_skin # assuming c = b
-        a_semi_major_skin = shape.b * b_semi_minor_skin
+        a_semi_major_skin = shape.aspect_ratio_b * b_semi_minor_skin
     else
         a_semi_major_skin = a_flesh + fat
         b_semi_minor_skin = b_flesh + fat
@@ -68,18 +68,18 @@ function geometry(shape::Ellipsoid, fur::Fur, fat::Fat)
     fat_volume = fat_mass / fat.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.b)) ^ (1 / 3)
+    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.aspect_ratio_b)) ^ (1 / 3)
     c_flesh = b_flesh # assuming c = b
-    a_flesh = shape.b * b_flesh
+    a_flesh = shape.aspect_ratio_b * b_flesh
     fat = prolate_fat_layer(
         ustrip(u"m^3", flesh_volume), 
         ustrip(u"m^3", fat_volume), 
-        shape.b, 
+        shape.aspect_ratio_b, 
         ustrip(u"m", b_flesh))
     if fat <= 0.0u"m"
-        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.b)) ^ (1 / 3)
+        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.aspect_ratio_b)) ^ (1 / 3)
         c_semi_minor_skin = b_semi_minor_skin # assuming c = b
-        a_semi_major_skin = shape.b * b_semi_minor_skin
+        a_semi_major_skin = shape.aspect_ratio_b * b_semi_minor_skin
     else
         a_semi_major_skin = a_flesh + fat
         b_semi_minor_skin = b_flesh + fat
@@ -103,18 +103,18 @@ end
 function prolate_fat_layer(
     flesh_volume,
     fat_volume,
-    shape_b,
+    aspect_ratio_b,
     semi_minor_flesh
 )
     # Flesh is approximated as a prolate spheroid:
     # Volume = 4/3 π * A * B * C
-    # C = B, A = shape_b * B
-    # → B = ((3 * volume) / (4 * shape_b * π))^(1/3)
+    # C = B, A = aspect_ratio_b * B
+    # → B = ((3 * volume) / (4 * aspect_ratio_b * π))^(1/3)
     # Fat thickness X is root of cubic: A X^3 + B X^2 + C X + D = 0
     A = 1.0
-    B = shape_b * semi_minor_flesh + 2 * semi_minor_flesh
-    C = 2 * shape_b * semi_minor_flesh^2 + semi_minor_flesh^2
-    D = shape_b * semi_minor_flesh^3 - (( (fat_volume + flesh_volume) * 3.0 ) / (4.0 * π))
+    B = aspect_ratio_b * semi_minor_flesh + 2 * semi_minor_flesh
+    C = 2 * aspect_ratio_b * semi_minor_flesh^2 + semi_minor_flesh^2
+    D = aspect_ratio_b * semi_minor_flesh^3 - (( (fat_volume + flesh_volume) * 3.0 ) / (4.0 * π))
 
     # Components of cubic formula
 

--- a/src/shapes/ellipsoid.jl
+++ b/src/shapes/ellipsoid.jl
@@ -220,19 +220,8 @@ function silhouette_area(shape::Ellipsoid, insulation::CompositeInsulation, body
     return silhouette_area(shape, a, b, c, θ)
 end
 
-<<<<<<< characteristic-dimension-options
-# characteristic dimension functions
-
-# For a prolate spheroid (a_semi_major > b_semi_minor = c_semi_minor), the shortest
-# linear dimension is the minor-axis diameter (2b).
-shortest_outer_dim(::Ellipsoid, ::Union{Naked,Fat}, geom)          = 2 * geom.length.b_semi_minor_skin
-shortest_outer_dim(::Ellipsoid, ::Union{Fur,CompositeInsulation}, geom) = 2 * geom.length.b_semi_minor_fur
-
-# radii functions
-=======
 # Radius
 
->>>>>>> main
 skin_radius(shape::Ellipsoid, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.length.b_semi_minor_skin
 
 # naked

--- a/src/shapes/ellipsoid.jl
+++ b/src/shapes/ellipsoid.jl
@@ -17,8 +17,7 @@ function geometry(shape::Ellipsoid, ::Naked)
     a_semi_major_skin = b_semi_minor_skin * shape.b
     e = ((ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) ^ (1 / 2)) / ustrip(u"m", a_semi_major_skin)
     total = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", b_semi_minor_skin), e)
-    characteristic_dimension = volume^(1 / 3) # b_semi_minor_skin * 2
-    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin), SurfaceAreas(; total))
+    return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin), SurfaceAreas(; total))
 end
 
 function geometry(shape::Ellipsoid, fur::Fur)
@@ -36,8 +35,7 @@ function geometry(shape::Ellipsoid, fur::Fur)
     skin = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
     area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair 
-    characteristic_dimension = volume^(1 / 3) + fur.thickness # b_semi_minor_fur * 2
-    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur), SurfaceAreas(; total, skin, convection))
+    return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur), SurfaceAreas(; total, skin, convection))
 end
 
 function geometry(shape::Ellipsoid, fat::Fat)
@@ -64,8 +62,7 @@ function geometry(shape::Ellipsoid, fat::Fat)
     end
     e = ((a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) ^ (1 / 2)) / a_semi_major_skin
     total = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
-    characteristic_dimension = volume^(1 / 3) # b_semi_minor_skin * 2
-    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, fat), SurfaceAreas(; total))
+    return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, fat), SurfaceAreas(; total))
 end
 
 function geometry(shape::Ellipsoid, fur::Fur, fat::Fat)
@@ -100,8 +97,7 @@ function geometry(shape::Ellipsoid, fur::Fur, fat::Fat)
     skin = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
     area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair 
-    characteristic_dimension = volume^(1 / 3) + fur.thickness # b_semi_minor_fur * 2
-    return Geometry(volume, characteristic_dimension, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur, fat), SurfaceAreas(; total, skin, convection))
+    return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, a_semi_major_fur, b_semi_minor_fur, c_semi_minor_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 # fat thickness calculation

--- a/src/shapes/ellipsoid.jl
+++ b/src/shapes/ellipsoid.jl
@@ -3,7 +3,7 @@
 
 An ellipsoidal organism shape.
 """
-mutable struct Ellipsoid{M,D,B,C} <: AbstractShape
+struct Ellipsoid{M,D,B,C} <: AbstractShape
     mass::M
     density::D
     b::B
@@ -238,6 +238,13 @@ function silhouette_area(shape::Ellipsoid, insulation::CompositeInsulation, body
     c = body.geometry.length.c_semi_minor_fur
     return silhouette_area(shape, a, b, c, θ)
 end
+
+# characteristic dimension functions
+
+# For a prolate spheroid (a_semi_major > b_semi_minor = c_semi_minor), the shortest
+# linear dimension is the minor-axis diameter (2b).
+shortest_outer_dim(::Ellipsoid, ::Union{Naked,Fat}, geom)          = 2 * geom.length.b_semi_minor_skin
+shortest_outer_dim(::Ellipsoid, ::Union{Fur,CompositeInsulation}, geom) = 2 * geom.length.b_semi_minor_fur
 
 # radii functions
 skin_radius(shape::Ellipsoid, insulation::AbstractInsulation, body::AbstractBody) = body.geometry.length.b_semi_minor_skin

--- a/src/shapes/leopard_frog.jl
+++ b/src/shapes/leopard_frog.jl
@@ -33,15 +33,6 @@ end
 
 # Radius
 
-<<<<<<< characteristic-dimension-options
-# characteristic dimension functions
-
-# Same cylinder approximation as DesertIguana: L=2D=4R, shortest dimension is diameter (2r).
-shortest_outer_dim(::LeopardFrog, ::Naked, geom) = 2 * geom.length.r_skin
-
-# "radii" functions
-=======
->>>>>>> main
 skin_radius(shape::LeopardFrog, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin
 insulation_radius(shape::LeopardFrog, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin
 flesh_radius(shape::LeopardFrog, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin

--- a/src/shapes/leopard_frog.jl
+++ b/src/shapes/leopard_frog.jl
@@ -34,6 +34,11 @@ end
 
 # surface area and radii functions
 
+# characteristic dimension functions
+
+# Same cylinder approximation as DesertIguana: L=2D=4R, shortest dimension is diameter (2r).
+shortest_outer_dim(::LeopardFrog, ::Naked, geom) = 2 * geom.length.r_skin
+
 # "radii" functions
 skin_radius(shape::LeopardFrog, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin
 insulation_radius(shape::LeopardFrog, insulation::Naked, body::AbstractBody) = body.geometry.length.r_skin

--- a/src/shapes/leopard_frog.jl
+++ b/src/shapes/leopard_frog.jl
@@ -10,10 +10,9 @@ end
 
 function geometry(shape::LeopardFrog, ::Naked)
     volume = shape.mass / shape.density
-    characteristic_dimension = volume^(1 / 3)
     r_skin = (volume / (4 * π)) ^ (1 / 3)
     total = surface_area(shape)
-    return Geometry(volume, characteristic_dimension, (; r_skin), SurfaceAreas(; total))
+    return Geometry(volume, (; r_skin), SurfaceAreas(; total))
 end
 
 # area functions

--- a/src/shapes/plate.jl
+++ b/src/shapes/plate.jl
@@ -3,7 +3,7 @@
 
 A flat plate-shaped organism shape.
 """
-mutable struct Plate{M,D,B,C} <: AbstractShape
+struct Plate{M,D,B,C} <: AbstractShape
     mass::M
     density::D
     b::B
@@ -102,6 +102,13 @@ function silhouette_area(shape::Plate, insulation::Union{Fur,CompositeInsulation
     parallel = min(length * width, length * height, height * width)
     return (; normal, parallel)
 end
+
+# characteristic dimension functions
+
+shortest_outer_dim(::Plate, ::Union{Naked,Fat}, geom) =
+    min(geom.length.length_skin, geom.length.width_skin, geom.length.height_skin)
+shortest_outer_dim(::Plate, ::Union{Fur,CompositeInsulation}, geom) =
+    min(geom.length.length_fur, geom.length.width_fur, geom.length.height_fur)
 
 # radii functions
 

--- a/src/shapes/plate.jl
+++ b/src/shapes/plate.jl
@@ -95,7 +95,6 @@ function silhouette_area(shape::Plate, insulation::Union{Fur,CompositeInsulation
     return (; normal, parallel)
 end
 
-<<<<<<< characteristic-dimension-options
 # characteristic dimension functions
 
 shortest_outer_dim(::Plate, ::Union{Naked,Fat}, geom) =
@@ -104,9 +103,6 @@ shortest_outer_dim(::Plate, ::Union{Fur,CompositeInsulation}, geom) =
     min(geom.length.length_fur, geom.length.width_fur, geom.length.height_fur)
 
 # radii functions
-=======
-# Radius
->>>>>>> main
 
 skin_radius(shape::Plate, insulation::AbstractInsulation, body) = body.geometry.length.width_skin / 2
 

--- a/src/shapes/plate.jl
+++ b/src/shapes/plate.jl
@@ -6,62 +6,62 @@ A flat plate-shaped organism shape.
 struct Plate{M,D,B,C} <: AbstractShape
     mass::M
     density::D
-    aspect_ratio_b::B
-    aspect_ratio_c::C
+    axis_ratio_b::B
+    axis_ratio_c::C
 end
 
 function geometry(shape::Plate, ::Naked)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3)
-    width_skin = length_skin / shape.aspect_ratio_b
-    height_skin = length_skin / shape.aspect_ratio_c 
+    length_skin = (volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3)
+    width_skin = length_skin / shape.axis_ratio_b
+    height_skin = length_skin / shape.axis_ratio_c 
     total = surface_area(shape, length_skin, width_skin, height_skin)
     return Geometry(volume, (; length_skin, width_skin, height_skin), SurfaceAreas(; total))
 end
-function geometry(shape::Plate, fur::Fur)
+function geometry(shape::Plate, fibrous_layer::FibrousLayer)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3)
-    width_skin = length_skin / shape.aspect_ratio_b
-    height_skin = length_skin / shape.aspect_ratio_c 
-    length_fur = length_skin + fur.thickness * 2
-    width_fur = width_skin + fur.thickness * 2
-    height_fur = height_skin + fur.thickness * 2
+    length_skin = (volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3)
+    width_skin = length_skin / shape.axis_ratio_b
+    height_skin = length_skin / shape.axis_ratio_c
+    length_fur = length_skin + fibrous_layer.thickness * 2
+    width_fur = width_skin + fibrous_layer.thickness * 2
+    height_fur = height_skin + fibrous_layer.thickness * 2
     total = surface_area(shape, length_fur, width_fur, height_fur)
     skin = surface_area(shape, length_skin, width_skin, height_skin)
-    area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
+    area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
     convection = skin - area_hair
     fat = 0.0u"m"
     return Geometry(volume, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), SurfaceAreas(; total, skin, convection))
 end
-function geometry(shape::Plate, fat::Fat)
+function geometry(shape::Plate, fat_layer::FatLayer)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3)
-    width_skin = length_skin / shape.aspect_ratio_b
-    height_skin = length_skin / shape.aspect_ratio_c 
-    fat_mass = shape.mass * fat.fraction
-    fat_volume = fat_mass / fat.density
+    length_skin = (volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3)
+    width_skin = length_skin / shape.axis_ratio_b
+    height_skin = length_skin / shape.axis_ratio_c
+    fat_mass = shape.mass * fat_layer.fraction
+    fat_volume = fat_mass / fat_layer.density
     flesh_volume = volume - fat_volume
-    width_flesh = (flesh_volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3) / shape.aspect_ratio_b
+    width_flesh = (flesh_volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3) / shape.axis_ratio_b
     fat = (width_skin - width_flesh) / 2
     total = surface_area(shape, length_skin, width_skin, height_skin)
     return Geometry(volume, (; length_skin, width_skin, height_skin, fat), SurfaceAreas(; total))
 end
-function geometry(shape::Plate, fur::Fur, fat::Fat)
+function geometry(shape::Plate, fibrous_layer::FibrousLayer, fat_layer::FatLayer)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3)
-    width_skin = length_skin / shape.aspect_ratio_b
-    height_skin = length_skin / shape.aspect_ratio_c
-    fat_mass = shape.mass * fat.fraction
-    fat_volume = fat_mass / fat.density
+    length_skin = (volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3)
+    width_skin = length_skin / shape.axis_ratio_b
+    height_skin = length_skin / shape.axis_ratio_c
+    fat_mass = shape.mass * fat_layer.fraction
+    fat_volume = fat_mass / fat_layer.density
     flesh_volume = volume - fat_volume
-    width_flesh = (flesh_volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3) / shape.aspect_ratio_b
+    width_flesh = (flesh_volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3) / shape.axis_ratio_b
     fat = (width_skin - width_flesh) / 2
-    length_fur = length_skin + fur.thickness * 2
-    width_fur = width_skin + fur.thickness * 2
-    height_fur = height_skin + fur.thickness * 2
+    length_fur = length_skin + fibrous_layer.thickness * 2
+    width_fur = width_skin + fibrous_layer.thickness * 2
+    height_fur = height_skin + fibrous_layer.thickness * 2
     total = surface_area(shape, length_fur, width_fur, height_fur)
     skin = surface_area(shape, length_skin, width_skin, height_skin)
-    area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
+    area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
     convection = skin - area_hair
     return Geometry(volume, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), SurfaceAreas(; total, skin, convection))
 end
@@ -78,7 +78,7 @@ surface_area(shape::Plate, length, width, height) = length * width * 2 + length 
 
 # Silhouette area
 
-function silhouette_area(shape::Plate, insulation::Union{Naked,Fat}, body::AbstractBody)
+function silhouette_area(shape::Plate, insulation::Union{Naked,FatLayer}, body::AbstractBody)
     length = body.geometry.length.length_skin
     width = body.geometry.length.width_skin
     height = body.geometry.length.height_skin
@@ -86,7 +86,7 @@ function silhouette_area(shape::Plate, insulation::Union{Naked,Fat}, body::Abstr
     parallel = min(length * width, length * height, height * width)
     return (; normal, parallel)
 end
-function silhouette_area(shape::Plate, insulation::Union{Fur,CompositeInsulation}, body::AbstractBody)
+function silhouette_area(shape::Plate, insulation::Union{FibrousLayer,CompositeInsulation}, body::AbstractBody)
     length = body.geometry.length.length_fur
     width = body.geometry.length.width_fur
     height = body.geometry.length.height_fur
@@ -97,26 +97,26 @@ end
 
 # characteristic dimension functions
 
-shortest_outer_dim(::Plate, ::Union{Naked,Fat}, geom) =
+shortest_outer_dim(::Plate, ::Union{Naked,FatLayer}, geom) =
     min(geom.length.length_skin, geom.length.width_skin, geom.length.height_skin)
-shortest_outer_dim(::Plate, ::Union{Fur,CompositeInsulation}, geom) =
+shortest_outer_dim(::Plate, ::Union{FibrousLayer,CompositeInsulation}, geom) =
     min(geom.length.length_fur, geom.length.width_fur, geom.length.height_fur)
 
 # radii functions
 
-skin_radius(shape::Plate, insulation::AbstractInsulation, body) = body.geometry.length.width_skin / 2
+skin_radius(shape::Plate, insulation::AbstractInsulationLayer, body) = body.geometry.length.width_skin / 2
 
 # naked
 insulation_radius(shape::Plate, insulation::Naked, body) = body.geometry.length.width_skin / 2
 flesh_radius(shape::Plate, insulation::Naked, body) = body.geometry.length.width_skin / 2
 
 # fur
-insulation_radius(shape::Plate, insulation::Fur, body) = body.geometry.length.width_fur / 2
-flesh_radius(shape::Plate, insulation::Fur, body) = body.geometry.length.width_skin / 2
+insulation_radius(shape::Plate, insulation::FibrousLayer, body) = body.geometry.length.width_fur / 2
+flesh_radius(shape::Plate, insulation::FibrousLayer, body) = body.geometry.length.width_skin / 2
 
 # fat
-insulation_radius(shape::Plate, insulation::Fat, body) = body.geometry.length.width_skin / 2
-flesh_radius(shape::Plate, insulation::Fat, body) = body.geometry.length.width_skin / 2 - body.geometry.length.fat
+insulation_radius(shape::Plate, insulation::FatLayer, body) = body.geometry.length.width_skin / 2
+flesh_radius(shape::Plate, insulation::FatLayer, body) = body.geometry.length.width_skin / 2 - body.geometry.length.fat
 
 # fur plus fat
 insulation_radius(shape::Plate, insulation::CompositeInsulation, body) = body.geometry.length.width_fur / 2

--- a/src/shapes/plate.jl
+++ b/src/shapes/plate.jl
@@ -6,23 +6,23 @@ A flat plate-shaped organism shape.
 struct Plate{M,D,B,C} <: AbstractShape
     mass::M
     density::D
-    b::B
-    c::C
+    aspect_ratio_b::B
+    aspect_ratio_c::C
 end
 
 function geometry(shape::Plate, ::Naked)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.b * shape.c)^(1 / 3)
-    width_skin = length_skin / shape.b
-    height_skin = length_skin / shape.c 
+    length_skin = (volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3)
+    width_skin = length_skin / shape.aspect_ratio_b
+    height_skin = length_skin / shape.aspect_ratio_c 
     total = surface_area(shape, length_skin, width_skin, height_skin)
     return Geometry(volume, (; length_skin, width_skin, height_skin), SurfaceAreas(; total))
 end
 function geometry(shape::Plate, fur::Fur)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.b * shape.c)^(1 / 3)
-    width_skin = length_skin / shape.b
-    height_skin = length_skin / shape.c 
+    length_skin = (volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3)
+    width_skin = length_skin / shape.aspect_ratio_b
+    height_skin = length_skin / shape.aspect_ratio_c 
     length_fur = length_skin + fur.thickness * 2
     width_fur = width_skin + fur.thickness * 2
     height_fur = height_skin + fur.thickness * 2
@@ -35,26 +35,26 @@ function geometry(shape::Plate, fur::Fur)
 end
 function geometry(shape::Plate, fat::Fat)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.b * shape.c)^(1 / 3)
-    width_skin = length_skin / shape.b
-    height_skin = length_skin / shape.c 
+    length_skin = (volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3)
+    width_skin = length_skin / shape.aspect_ratio_b
+    height_skin = length_skin / shape.aspect_ratio_c 
     fat_mass = shape.mass * fat.fraction
     fat_volume = fat_mass / fat.density
     flesh_volume = volume - fat_volume
-    width_flesh = (flesh_volume * shape.b * shape.c)^(1 / 3) / shape.b
+    width_flesh = (flesh_volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3) / shape.aspect_ratio_b
     fat = (width_skin - width_flesh) / 2
     total = surface_area(shape, length_skin, width_skin, height_skin)
     return Geometry(volume, (; length_skin, width_skin, height_skin, fat), SurfaceAreas(; total))
 end
 function geometry(shape::Plate, fur::Fur, fat::Fat)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.b * shape.c)^(1 / 3)
-    width_skin = length_skin / shape.b
-    height_skin = length_skin / shape.c
+    length_skin = (volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3)
+    width_skin = length_skin / shape.aspect_ratio_b
+    height_skin = length_skin / shape.aspect_ratio_c
     fat_mass = shape.mass * fat.fraction
     fat_volume = fat_mass / fat.density
     flesh_volume = volume - fat_volume
-    width_flesh = (flesh_volume * shape.b * shape.c)^(1 / 3) / shape.b
+    width_flesh = (flesh_volume * shape.aspect_ratio_b * shape.aspect_ratio_c)^(1 / 3) / shape.aspect_ratio_b
     fat = (width_skin - width_flesh) / 2
     length_fur = length_skin + fur.thickness * 2
     width_fur = width_skin + fur.thickness * 2

--- a/src/shapes/plate.jl
+++ b/src/shapes/plate.jl
@@ -16,8 +16,7 @@ function geometry(shape::Plate, ::Naked)
     width_skin = length_skin / shape.b
     height_skin = length_skin / shape.c 
     total = surface_area(shape, length_skin, width_skin, height_skin)
-    characteristic_dimension = volume^(1 / 3) # width_skin * 2
-    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin), SurfaceAreas(; total))
+    return Geometry(volume, (; length_skin, width_skin, height_skin), SurfaceAreas(; total))
 end
 
 function geometry(shape::Plate, fur::Fur)
@@ -33,8 +32,7 @@ function geometry(shape::Plate, fur::Fur)
     area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
     fat = 0.0u"m"
-    characteristic_dimension = volume^(1 / 3) + fur.thickness # width_fur * 2
-    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), SurfaceAreas(; total, skin, convection))
+    return Geometry(volume, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 function geometry(shape::Plate, fat::Fat)
@@ -48,8 +46,7 @@ function geometry(shape::Plate, fat::Fat)
     width_flesh = (flesh_volume * shape.b * shape.c)^(1 / 3) / shape.b
     fat = (width_skin - width_flesh) / 2
     total = surface_area(shape, length_skin, width_skin, height_skin)
-    characteristic_dimension = volume^(1 / 3) # width_skin * 2 
-    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin, fat), SurfaceAreas(; total))
+    return Geometry(volume, (; length_skin, width_skin, height_skin, fat), SurfaceAreas(; total))
 end
 
 function geometry(shape::Plate, fur::Fur, fat::Fat)
@@ -69,8 +66,7 @@ function geometry(shape::Plate, fur::Fur, fat::Fat)
     skin = surface_area(shape, length_skin, width_skin, height_skin)
     area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
-    characteristic_dimension = volume^(1 / 3) + fur.thickness #width_fur * 2 
-    return Geometry(volume, characteristic_dimension, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), SurfaceAreas(; total, skin, convection))
+    return Geometry(volume, (; length_skin, width_skin, height_skin, length_fur, width_fur, height_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 # surface area functions

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -87,16 +87,7 @@ function silhouette_area(shape::Sphere, insulation::Union{Fur,CompositeInsulatio
     return (; normal, parallel)
 end
 
-<<<<<<< characteristic-dimension-options
-# characteristic dimension functions
-
-shortest_outer_dim(::Sphere, ::Union{Naked,Fat}, geom)          = 2 * geom.length.radius_skin
-shortest_outer_dim(::Sphere, ::Union{Fur,CompositeInsulation}, geom) = 2 * geom.length.radius_fur
-
-# radii functions
-=======
 # Radius
->>>>>>> main
 
 skin_radius(shape::Sphere, insulation::AbstractInsulation, body) = body.geometry.length.radius_skin
 

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -12,8 +12,7 @@ function geometry(shape::Sphere, ::Naked)
     volume = shape.mass / shape.density
     radius_skin = ((3 / 4) * volume / π) ^ (1 / 3)
     total = surface_area(shape, radius_skin)
-    characteristic_dimension = volume^(1 / 3) #radius_skin * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin), SurfaceAreas(; total))
+    return Geometry(volume, (; radius_skin), SurfaceAreas(; total))
 end
 
 function geometry(shape::Sphere, fur::Fur)
@@ -24,8 +23,7 @@ function geometry(shape::Sphere, fur::Fur)
     skin = surface_area(shape, radius_skin)
     area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
-    characteristic_dimension = volume^(1 / 3) + fur.thickness # radius_fur * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur), SurfaceAreas(; total, skin, convection))
+    return Geometry(volume, (; radius_skin, radius_fur), SurfaceAreas(; total, skin, convection))
 end
 
 function geometry(shape::Sphere, fat::Fat)
@@ -37,8 +35,7 @@ function geometry(shape::Sphere, fat::Fat)
     radius_flesh = ((3 / 4) * flesh_volume / π) ^ (1 / 3)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_skin)
-    characteristic_dimension = volume^(1 / 3) #radius_skin * 2 #
-    return Geometry(volume, characteristic_dimension, (; radius_skin, fat), SurfaceAreas(; total))
+    return Geometry(volume, (; radius_skin, fat), SurfaceAreas(; total))
 end
 
 function geometry(shape::Sphere, fur::Fur, fat::Fat)
@@ -54,8 +51,7 @@ function geometry(shape::Sphere, fur::Fur, fat::Fat)
     skin = surface_area(shape, radius_skin)
     area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
     convection = skin - area_hair
-    characteristic_dimension = volume^(1 / 3) + fur.thickness #radius_fur * 2
-    return Geometry(volume, characteristic_dimension, (; radius_skin, radius_fur, fat), SurfaceAreas(; total, skin, convection))
+    return Geometry(volume, (; radius_skin, radius_fur, fat), SurfaceAreas(; total, skin, convection))
 end
 
 # area functions

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -14,20 +14,20 @@ function geometry(shape::Sphere, ::Naked)
     total = surface_area(shape, radius_skin)
     return Geometry(volume, (; radius_skin), SurfaceAreas(; total))
 end
-function geometry(shape::Sphere, fur::Fur)
+function geometry(shape::Sphere, fibrous_layer::FibrousLayer)
     volume = shape.mass / shape.density
     radius_skin = ((3 / 4)* volume / π) ^ (1 / 3)
-    radius_fur = radius_skin + fur.thickness
+    radius_fur = radius_skin + fibrous_layer.thickness
     total = surface_area(shape, radius_fur)
     skin = surface_area(shape, radius_skin)
-    area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
+    area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
     convection = skin - area_hair
     return Geometry(volume, (; radius_skin, radius_fur), SurfaceAreas(; total, skin, convection))
 end
-function geometry(shape::Sphere, fat::Fat)
+function geometry(shape::Sphere, fat_layer::FatLayer)
     volume = shape.mass / shape.density
-    fat_mass = shape.mass * fat.fraction
-    fat_volume = fat_mass / fat.density
+    fat_mass = shape.mass * fat_layer.fraction
+    fat_volume = fat_mass / fat_layer.density
     flesh_volume = volume - fat_volume
     radius_skin = ((3 / 4) * volume / π) ^ (1 / 3)
     radius_flesh = ((3 / 4) * flesh_volume / π) ^ (1 / 3)
@@ -35,18 +35,18 @@ function geometry(shape::Sphere, fat::Fat)
     total = surface_area(shape, radius_skin)
     return Geometry(volume, (; radius_skin, fat), SurfaceAreas(; total))
 end
-function geometry(shape::Sphere, fur::Fur, fat::Fat)
+function geometry(shape::Sphere, fibrous_layer::FibrousLayer, fat_layer::FatLayer)
     volume = shape.mass / shape.density
-    fat_mass = shape.mass * fat.fraction
-    fat_volume = fat_mass / fat.density
+    fat_mass = shape.mass * fat_layer.fraction
+    fat_volume = fat_mass / fat_layer.density
     flesh_volume = volume - fat_volume
     radius_skin = ((3 / 4) * volume / π) ^ (1 / 3)
-    radius_fur = radius_skin + fur.thickness
+    radius_fur = radius_skin + fibrous_layer.thickness
     radius_flesh = ((3 / 4) * flesh_volume / π) ^ (1 / 3)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_fur)
     skin = surface_area(shape, radius_skin)
-    area_hair = insulation_area(fur.fibre_diameter, fur.fibre_density, skin)
+    area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
     convection = skin - area_hair
     return Geometry(volume, (; radius_skin, radius_fur, fat), SurfaceAreas(; total, skin, convection))
 end
@@ -64,22 +64,22 @@ end
 # Silhouette area
 
 silhouette_area(shape::Sphere, r) = π * r ^ 2
-function silhouette_area(shape::Sphere, insulation::Union{Naked,Fat}, body::AbstractBody, θ)
+function silhouette_area(shape::Sphere, insulation::Union{Naked,FatLayer}, body::AbstractBody, θ)
     r = body.geometry.length.radius_skin
     return silhouette_area(shape, r)
 end
-function silhouette_area(shape::Sphere, insulation::Union{Fur,CompositeInsulation}, body::AbstractBody, θ)
+function silhouette_area(shape::Sphere, insulation::Union{FibrousLayer,CompositeInsulation}, body::AbstractBody, θ)
     r = body.geometry.length.radius_fur
     return silhouette_area(shape, r)
 end
-function silhouette_area(shape::Sphere, insulation::Union{Naked,Fat}, body::AbstractBody)
+function silhouette_area(shape::Sphere, insulation::Union{Naked,FatLayer}, body::AbstractBody)
     r = body.geometry.length.radius_skin
     area = silhouette_area(shape, r)
     normal = area
     parallel = area
     return (; normal, parallel)
 end
-function silhouette_area(shape::Sphere, insulation::Union{Fur,CompositeInsulation}, body::AbstractBody)
+function silhouette_area(shape::Sphere, insulation::Union{FibrousLayer,CompositeInsulation}, body::AbstractBody)
     r = body.geometry.length.radius_fur
     area = silhouette_area(shape, r)
     normal = area
@@ -89,20 +89,20 @@ end
 
 # Radius
 
-skin_radius(shape::Sphere, insulation::AbstractInsulation, body) = body.geometry.length.radius_skin
+skin_radius(shape::Sphere, insulation::AbstractInsulationLayer, body) = body.geometry.length.radius_skin
 
 # naked
 insulation_radius(shape::Sphere, insulation::Naked, body) = body.geometry.length.radius_skin
 flesh_radius(shape::Sphere, insulation::Naked, body) = body.geometry.length.radius_skin
 
-# fur
-insulation_radius(shape::Sphere, insulation::Fur, body) = body.geometry.length.radius_fur
-flesh_radius(shape::Sphere, insulation::Fur, body) = body.geometry.length.radius_skin
+# fibrous layer
+insulation_radius(shape::Sphere, insulation::FibrousLayer, body) = body.geometry.length.radius_fur
+flesh_radius(shape::Sphere, insulation::FibrousLayer, body) = body.geometry.length.radius_skin
 
-# fat
-insulation_radius(shape::Sphere, insulation::Fat, body) = body.geometry.length.radius_skin
-flesh_radius(shape::Sphere, insulation::Fat, body) = body.geometry.length.radius_skin - body.geometry.length.fat
+# fat layer
+insulation_radius(shape::Sphere, insulation::FatLayer, body) = body.geometry.length.radius_skin
+flesh_radius(shape::Sphere, insulation::FatLayer, body) = body.geometry.length.radius_skin - body.geometry.length.fat
 
-# fur and fat
+# fibrous + fat layer
 insulation_radius(shape::Sphere, insulation::CompositeInsulation, body) = body.geometry.length.radius_fur
 flesh_radius(shape::Sphere, insulation::CompositeInsulation, body) = body.geometry.length.radius_skin - body.geometry.length.fat

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -3,7 +3,7 @@
 
 A spherical organism shape.
 """
-mutable struct Sphere{M,D} <: AbstractShape
+struct Sphere{M,D} <: AbstractShape
     mass::M
     density::D
 end
@@ -97,6 +97,11 @@ function silhouette_area(shape::Sphere, insulation::Union{Fur,CompositeInsulatio
     parallel = area
     return (; normal, parallel)
 end
+
+# characteristic dimension functions
+
+shortest_outer_dim(::Sphere, ::Union{Naked,Fat}, geom)          = 2 * geom.length.radius_skin
+shortest_outer_dim(::Sphere, ::Union{Fur,CompositeInsulation}, geom) = 2 * geom.length.radius_fur
 
 # radii functions
 

--- a/test/geometry.jl
+++ b/test/geometry.jl
@@ -5,8 +5,8 @@ using Test
 
 density = 1000.0u"kg/m^3"
 mass = 65.0u"kg"
-shape_b = 5.0
-shape_c = 5.0
+aspect_ratio_b = 5.0
+aspect_ratio_c = 5.0
 fur_thickness = 10.0u"mm"
 fibre_diameter = 30.0u"μm"
 fibre_density = 3000u"cm^-2"
@@ -17,7 +17,7 @@ fur = Fur(fur_thickness, fibre_diameter, fibre_density)
 fat = Fat(fat_fraction, fat_density)
 
 # plate
-shape = Plate(mass, density, shape_b, shape_c)
+shape = Plate(mass, density, aspect_ratio_b, aspect_ratio_c)
 body = Body(shape, Naked())
 
 total_area(body)
@@ -91,7 +91,7 @@ body.geometry.length
 body.geometry.volume
 
 # cylinder
-shape = Cylinder(mass, density, shape_b)
+shape = Cylinder(mass, density, aspect_ratio_b)
 body = Body(shape, Naked())
 
 total_area(body)
@@ -251,7 +251,7 @@ body.geometry.length
 body.geometry.volume
 
 # ellipsoid
-shape = Ellipsoid(mass, density, shape_b, shape_c)
+shape = Ellipsoid(mass, density, aspect_ratio_b, aspect_ratio_c)
 body = Body(shape, Naked())
 
 total_area(body)

--- a/test/geometry.jl
+++ b/test/geometry.jl
@@ -5,19 +5,19 @@ using Test
 
 density = 1000.0u"kg/m^3"
 mass = 65.0u"kg"
-aspect_ratio_b = 5.0
-aspect_ratio_c = 5.0
-fur_thickness = 10.0u"mm"
+axis_ratio_b = 5.0
+axis_ratio_c = 5.0
+fibrous_layer_thickness = 10.0u"mm"
 fibre_diameter = 30.0u"μm"
 fibre_density = 3000u"cm^-2"
 fat_fraction = 0.1
 fat_density = 901.0u"kg/m^3"
 
-fur = Fur(fur_thickness, fibre_diameter, fibre_density)
-fat = Fat(fat_fraction, fat_density)
+fibrous_layer = FibrousLayer(fibrous_layer_thickness, fibre_diameter, fibre_density)
+fat_layer = FatLayer(fat_fraction, fat_density)
 
 # plate
-shape = Plate(mass, density, aspect_ratio_b, aspect_ratio_c)
+shape = Plate(mass, density, axis_ratio_b, axis_ratio_c)
 body = Body(shape, Naked())
 
 total_area(body)
@@ -37,7 +37,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, fur)
+body = Body(shape, fibrous_layer)
 
 total_area(body)
 skin_area(body)
@@ -56,7 +56,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, fat)
+body = Body(shape, fat_layer)
 
 total_area(body)
 skin_area(body)
@@ -71,7 +71,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, CompositeInsulation(fur, fat))
+body = Body(shape, CompositeInsulation(fibrous_layer, fat_layer))
 
 total_area(body)
 skin_area(body)
@@ -91,7 +91,7 @@ body.geometry.length
 body.geometry.volume
 
 # cylinder
-shape = Cylinder(mass, density, aspect_ratio_b)
+shape = Cylinder(mass, density, axis_ratio_b)
 body = Body(shape, Naked())
 
 total_area(body)
@@ -112,7 +112,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, fur)
+body = Body(shape, fibrous_layer)
 
 total_area(body)
 skin_area(body)
@@ -132,7 +132,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, fat)
+body = Body(shape, fat_layer)
 
 total_area(body)
 skin_area(body)
@@ -152,7 +152,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, CompositeInsulation(fur, fat))
+body = Body(shape, CompositeInsulation(fibrous_layer, fat_layer))
 
 total_area(body)
 skin_area(body)
@@ -193,7 +193,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, fur)
+body = Body(shape, fibrous_layer)
 
 total_area(body)
 skin_area(body)
@@ -212,7 +212,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, fat)
+body = Body(shape, fat_layer)
 
 total_area(body)
 skin_area(body)
@@ -231,7 +231,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, CompositeInsulation(fur, fat))
+body = Body(shape, CompositeInsulation(fibrous_layer, fat_layer))
 
 total_area(body)
 skin_area(body)
@@ -251,7 +251,7 @@ body.geometry.length
 body.geometry.volume
 
 # ellipsoid
-shape = Ellipsoid(mass, density, aspect_ratio_b, aspect_ratio_c)
+shape = Ellipsoid(mass, density, axis_ratio_b, axis_ratio_c)
 body = Body(shape, Naked())
 
 total_area(body)
@@ -272,7 +272,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, fur)
+body = Body(shape, fibrous_layer)
 
 total_area(body)
 skin_area(body)
@@ -292,7 +292,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, fat)
+body = Body(shape, fat_layer)
 
 total_area(body)
 skin_area(body)
@@ -312,7 +312,7 @@ body.geometry.area
 body.geometry.length
 body.geometry.volume
 
-body = Body(shape, CompositeInsulation(fur, fat))
+body = Body(shape, CompositeInsulation(fibrous_layer, fat_layer))
 
 total_area(body)
 skin_area(body)


### PR DESCRIPTION
This PR includes a significant change in terms for insulation. Whereas before we had "Fat" and "Fur" structs, we now have FatLayer and FibrousLayer which are members of abstract types AbstractSolidLayer and AbstractPorousLayer, respectively. We can now generalise across different types of insulation (fur, feathers, keratin layers, outer bone layers etc.) and specialise structs holdling insulation properties for other types of insulation down the track.

This PR additionally removes the characteristic dimension parameter and just computes the linear dimensions, with characteristic dimension calulations moved into HeatExchange.jl where there are more options for how this parameter is calculated. And it makes some previously mutable structs immutable.