### PR TITLE
Unitful friendly square and cube roots

### DIFF
--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -11,14 +11,14 @@ end
 
 function geometry(shape::Cylinder, ::Naked)
     volume = shape.mass / shape.density
-    radius_skin = (volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    radius_skin = cbrt(volume / (shape.axis_ratio_b * π * 2))
     length_skin = shape.axis_ratio_b * radius_skin * 2
     total = surface_area(shape, radius_skin, length_skin)
     return Geometry(volume, (; length_skin, radius_skin), SurfaceAreas(; total))
 end
 function geometry(shape::Cylinder, fibrous_layer::FibrousLayer)
     volume = shape.mass / shape.density
-    radius_skin = (volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    radius_skin = cbrt(volume / (shape.axis_ratio_b * π * 2))
     radius_fur = radius_skin + fibrous_layer.thickness
     length_skin = shape.axis_ratio_b * radius_skin * 2
     length_fur = shape.axis_ratio_b * radius_skin * 2 + fibrous_layer.thickness * 2
@@ -33,9 +33,9 @@ function geometry(shape::Cylinder, fat_layer::FatLayer)
     fat_volume = fat_mass / fat_layer.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    radius_skin = (volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    radius_skin = cbrt(volume / (shape.axis_ratio_b * π * 2))
     length_skin = shape.axis_ratio_b * radius_skin * 2
-    radius_flesh = (flesh_volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    radius_flesh = cbrt(flesh_volume / (shape.axis_ratio_b * π * 2))
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_skin, length_skin)
     return Geometry(volume, (; radius_skin, length_skin, fat), SurfaceAreas(; total))
@@ -45,11 +45,11 @@ function geometry(shape::Cylinder, fibrous_layer::FibrousLayer, fat_layer::FatLa
     fat_volume = fat_mass / fat_layer.density
     volume = shape.mass / shape.density
     flesh_volume = volume - fat_volume
-    radius_skin = (volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    radius_skin = cbrt(volume / (shape.axis_ratio_b * π * 2))
     radius_fur = radius_skin + fibrous_layer.thickness
     length_skin = shape.axis_ratio_b * radius_skin * 2
     length_fur = shape.axis_ratio_b * radius_skin * 2 + fibrous_layer.thickness * 2
-    radius_flesh = (flesh_volume / (shape.axis_ratio_b * π * 2))^(1 / 3)
+    radius_flesh = cbrt(flesh_volume / (shape.axis_ratio_b * π * 2))
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_fur, length_fur)
     skin = surface_area(shape, radius_skin, length_skin)

--- a/src/shapes/desert_iguana.jl
+++ b/src/shapes/desert_iguana.jl
@@ -17,7 +17,7 @@ end
 function geometry(shape::DesertIguana, ::Naked)
     volume = shape.mass / shape.density
     # Cylinder approximation for body dimensions: assume L=2D=4R, so vol=4π R³
-    r_skin = (volume / (4 * π)) ^ (1 / 3)
+    r_skin = cbrt(volume / (4 * π))
     # Surface areas from allometric functions (Porter and Tracy 1984)
     total, ventral = surface_area(shape)
     return Geometry(volume, (; r_skin), SurfaceAreas(; total, ventral))

--- a/src/shapes/ellipsoid.jl
+++ b/src/shapes/ellipsoid.jl
@@ -11,25 +11,35 @@ struct Ellipsoid{M,D,B,C} <: AbstractShape
 end
 
 function geometry(shape::Ellipsoid, ::Naked)
-    volume = shape.mass / shape.density
-    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.axis_ratio_b)) ^ (1 / 3)
+    # Canonicalise to m^3. Without this, mass/density carries the literal
+    # unit ratio (e.g. g/(kg/m^3) = g·m^3/kg). Downstream `cbrt` then yields a
+    # weird (g^1/3·kg^-1/3·m) length unit, while the `b_flesh + fat` branch
+    # below produces clean `m`. The if/else then has Union-typed locals,
+    # which trips Enzyme's typeunstablerules path.
+    volume = uconvert(u"m^3", shape.mass / shape.density)
+    b_semi_minor_skin = cbrt((3 / 4) * volume / (π * shape.axis_ratio_b))
     c_semi_minor_skin = b_semi_minor_skin
     a_semi_major_skin = b_semi_minor_skin * shape.axis_ratio_b
-    e = ((ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) ^ (1 / 2)) / ustrip(u"m", a_semi_major_skin)
+    e = sqrt(ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) / ustrip(u"m", a_semi_major_skin)
     total = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", b_semi_minor_skin), e)
     return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin), SurfaceAreas(; total))
 end
 function geometry(shape::Ellipsoid, fibrous_layer::FibrousLayer)
-    volume = shape.mass / shape.density
-    b_semi_minor_skin = ((3 / 4) * volume / (π * shape.axis_ratio_b)) ^ (1 / 3)
+    # Canonicalise to m^3. Without this, mass/density carries the literal
+    # unit ratio (e.g. g/(kg/m^3) = g·m^3/kg). Downstream `cbrt` then yields a
+    # weird (g^1/3·kg^-1/3·m) length unit, while the `b_flesh + fat` branch
+    # below produces clean `m`. The if/else then has Union-typed locals,
+    # which trips Enzyme's typeunstablerules path.
+    volume = uconvert(u"m^3", shape.mass / shape.density)
+    b_semi_minor_skin = cbrt((3 / 4) * volume / (π * shape.axis_ratio_b))
     c_semi_minor_skin = b_semi_minor_skin
     a_semi_major_skin = b_semi_minor_skin * shape.axis_ratio_b
-    e = ((ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) ^ (1 / 2)) / ustrip(u"m", a_semi_major_skin)
+    e = sqrt(ustrip(u"m", a_semi_major_skin) ^ 2 - ustrip(u"m", c_semi_minor_skin) ^ 2) / ustrip(u"m", a_semi_major_skin)
     a_semi_major_fur = a_semi_major_skin + fibrous_layer.thickness
     b_semi_minor_fur = b_semi_minor_skin + fibrous_layer.thickness
     c_semi_minor_fur = c_semi_minor_skin + fibrous_layer.thickness
-    e = ((a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) ^ (1 / 2)) / a_semi_major_skin
-    e_fur = ((a_semi_major_fur ^ 2 - c_semi_minor_fur ^ 2) ^ (1 / 2)) / a_semi_major_fur
+    e = sqrt(a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) / a_semi_major_skin
+    e_fur = sqrt(a_semi_major_fur ^ 2 - c_semi_minor_fur ^ 2) / a_semi_major_fur
     total = surface_area(shape, ustrip(u"m", a_semi_major_fur),  ustrip(u"m", b_semi_minor_fur),  ustrip(u"m", c_semi_minor_fur),  e_fur)
     skin = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
     area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
@@ -38,10 +48,15 @@ function geometry(shape::Ellipsoid, fibrous_layer::FibrousLayer)
 end
 function geometry(shape::Ellipsoid, fat_layer::FatLayer)
     fat_mass = shape.mass * fat_layer.fraction
-    fat_volume = fat_mass / fat_layer.density
-    volume = shape.mass / shape.density
+    fat_volume = uconvert(u"m^3", fat_mass / fat_layer.density)
+    # Canonicalise to m^3. Without this, mass/density carries the literal
+    # unit ratio (e.g. g/(kg/m^3) = g·m^3/kg). Downstream `cbrt` then yields a
+    # weird (g^1/3·kg^-1/3·m) length unit, while the `b_flesh + fat` branch
+    # below produces clean `m`. The if/else then has Union-typed locals,
+    # which trips Enzyme's typeunstablerules path.
+    volume = uconvert(u"m^3", shape.mass / shape.density)
     flesh_volume = volume - fat_volume
-    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.axis_ratio_b)) ^ (1 / 3)
+    b_flesh = cbrt(((3 / 4) * flesh_volume) / (π * shape.axis_ratio_b))
     c_flesh = b_flesh # assuming c = b
     a_flesh = shape.axis_ratio_b * b_flesh
     fat = prolate_fat_layer(
@@ -50,7 +65,7 @@ function geometry(shape::Ellipsoid, fat_layer::FatLayer)
         shape.axis_ratio_b,
         ustrip(u"m", b_flesh))
     if fat <= 0.0u"m"
-        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.axis_ratio_b)) ^ (1 / 3)
+        b_semi_minor_skin = cbrt(((3 / 4) * volume) / (π * shape.axis_ratio_b))
         c_semi_minor_skin = b_semi_minor_skin # assuming c = b
         a_semi_major_skin = shape.axis_ratio_b * b_semi_minor_skin
     else
@@ -58,17 +73,22 @@ function geometry(shape::Ellipsoid, fat_layer::FatLayer)
         b_semi_minor_skin = b_flesh + fat
         c_semi_minor_skin = c_flesh + fat
     end
-    e = ((a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) ^ (1 / 2)) / a_semi_major_skin
+    e = sqrt(a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) / a_semi_major_skin
     total = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
     return Geometry(volume, (; a_semi_major_skin, b_semi_minor_skin, c_semi_minor_skin, fat), SurfaceAreas(; total))
 end
 function geometry(shape::Ellipsoid, fibrous_layer::FibrousLayer, fat_layer::FatLayer)
     # TODO reduce duplication here
     fat_mass = shape.mass * fat_layer.fraction
-    fat_volume = fat_mass / fat_layer.density
-    volume = shape.mass / shape.density
+    fat_volume = uconvert(u"m^3", fat_mass / fat_layer.density)
+    # Canonicalise to m^3. Without this, mass/density carries the literal
+    # unit ratio (e.g. g/(kg/m^3) = g·m^3/kg). Downstream `cbrt` then yields a
+    # weird (g^1/3·kg^-1/3·m) length unit, while the `b_flesh + fat` branch
+    # below produces clean `m`. The if/else then has Union-typed locals,
+    # which trips Enzyme's typeunstablerules path.
+    volume = uconvert(u"m^3", shape.mass / shape.density)
     flesh_volume = volume - fat_volume
-    b_flesh = (((3 / 4) * flesh_volume) / (π * shape.axis_ratio_b)) ^ (1 / 3)
+    b_flesh = cbrt(((3 / 4) * flesh_volume) / (π * shape.axis_ratio_b))
     c_flesh = b_flesh # assuming c = b
     a_flesh = shape.axis_ratio_b * b_flesh
     fat = prolate_fat_layer(
@@ -77,7 +97,7 @@ function geometry(shape::Ellipsoid, fibrous_layer::FibrousLayer, fat_layer::FatL
         shape.axis_ratio_b,
         ustrip(u"m", b_flesh))
     if fat <= 0.0u"m"
-        b_semi_minor_skin = (((3 / 4) * volume) / (π * shape.axis_ratio_b)) ^ (1 / 3)
+        b_semi_minor_skin = cbrt(((3 / 4) * volume) / (π * shape.axis_ratio_b))
         c_semi_minor_skin = b_semi_minor_skin # assuming c = b
         a_semi_major_skin = shape.axis_ratio_b * b_semi_minor_skin
     else
@@ -85,12 +105,12 @@ function geometry(shape::Ellipsoid, fibrous_layer::FibrousLayer, fat_layer::FatL
         b_semi_minor_skin = b_flesh + fat
         c_semi_minor_skin = c_flesh + fat
     end
-    e = ((a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) ^ (1 / 2)) / a_semi_major_skin
+    e = sqrt(a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) / a_semi_major_skin
     a_semi_major_fur = a_semi_major_skin + fibrous_layer.thickness
     b_semi_minor_fur = b_semi_minor_skin + fibrous_layer.thickness
     c_semi_minor_fur = c_semi_minor_skin + fibrous_layer.thickness
-    e = ((a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) ^ (1 / 2)) / a_semi_major_skin
-    e_fur = ((a_semi_major_fur ^ 2 - c_semi_minor_fur ^ 2) ^ (1 / 2)) / a_semi_major_fur
+    e = sqrt(a_semi_major_skin ^ 2 - c_semi_minor_skin ^ 2) / a_semi_major_skin
+    e_fur = sqrt(a_semi_major_fur ^ 2 - c_semi_minor_fur ^ 2) / a_semi_major_fur
     total = surface_area(shape, ustrip(u"m", a_semi_major_fur),  ustrip(u"m", b_semi_minor_fur),  ustrip(u"m", c_semi_minor_fur),  e_fur)
     skin = surface_area(shape, ustrip(u"m", a_semi_major_skin), ustrip(u"m", b_semi_minor_skin), ustrip(u"m", c_semi_minor_skin), e)
     area_hair = insulation_area(fibrous_layer.fibre_diameter, fibrous_layer.fibre_density, skin)
@@ -109,7 +129,7 @@ function prolate_fat_layer(
     # Flesh is approximated as a prolate spheroid:
     # Volume = 4/3 π * A * B * C
     # C = B, A = axis_ratio_b * B
-    # → B = ((3 * volume) / (4 * axis_ratio_b * π))^(1/3)
+    # → B = ((3 * volume) / (4 * axis_ratio_b * π))^(1//3)
     # Fat thickness X is root of cubic: A X^3 + B X^2 + C X + D = 0
     A = 1.0
     B = axis_ratio_b * semi_minor_flesh + 2 * semi_minor_flesh
@@ -134,7 +154,14 @@ function prolate_fat_layer(
     # Cube roots with sign handling
 
     function signed_cuberoot(x)
-        x < 0 ? -((-x)^(1/3)) : x^(1/3)
+        # cbrt'(0) is +∞, which is mathematically correct but propagates as
+        # NaN through Enzyme when chained with very-small (Cardano formula
+        # discriminant) values. The cubic root of an effectively-zero
+        # discriminant is itself effectively zero with effectively-zero
+        # contribution to the cubic's solution, so clamp the singular point
+        # to zero to keep the derivative finite.
+        abs(x) < 1e-12 && return zero(x)
+        x < 0 ? -((-x)^(1//3)) : x^(1//3)
     end
 
     root1 = signed_cuberoot(T1 + T2)

--- a/src/shapes/leopard_frog.jl
+++ b/src/shapes/leopard_frog.jl
@@ -10,7 +10,7 @@ end
 
 function geometry(shape::LeopardFrog, ::Naked)
     volume = shape.mass / shape.density
-    r_skin = (volume / (4 * π)) ^ (1 / 3)
+    r_skin = cbrt(volume / (4 * π))
     total = surface_area(shape)
     return Geometry(volume, (; r_skin), SurfaceAreas(; total))
 end

--- a/src/shapes/plate.jl
+++ b/src/shapes/plate.jl
@@ -12,7 +12,7 @@ end
 
 function geometry(shape::Plate, ::Naked)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3)
+    length_skin = cbrt(volume * shape.axis_ratio_b * shape.axis_ratio_c)
     width_skin = length_skin / shape.axis_ratio_b
     height_skin = length_skin / shape.axis_ratio_c 
     total = surface_area(shape, length_skin, width_skin, height_skin)
@@ -20,7 +20,7 @@ function geometry(shape::Plate, ::Naked)
 end
 function geometry(shape::Plate, fibrous_layer::FibrousLayer)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3)
+    length_skin = cbrt(volume * shape.axis_ratio_b * shape.axis_ratio_c)
     width_skin = length_skin / shape.axis_ratio_b
     height_skin = length_skin / shape.axis_ratio_c
     length_fur = length_skin + fibrous_layer.thickness * 2
@@ -35,26 +35,26 @@ function geometry(shape::Plate, fibrous_layer::FibrousLayer)
 end
 function geometry(shape::Plate, fat_layer::FatLayer)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3)
+    length_skin = cbrt(volume * shape.axis_ratio_b * shape.axis_ratio_c)
     width_skin = length_skin / shape.axis_ratio_b
     height_skin = length_skin / shape.axis_ratio_c
     fat_mass = shape.mass * fat_layer.fraction
     fat_volume = fat_mass / fat_layer.density
     flesh_volume = volume - fat_volume
-    width_flesh = (flesh_volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3) / shape.axis_ratio_b
+    width_flesh = cbrt(flesh_volume * shape.axis_ratio_b * shape.axis_ratio_c) / shape.axis_ratio_b
     fat = (width_skin - width_flesh) / 2
     total = surface_area(shape, length_skin, width_skin, height_skin)
     return Geometry(volume, (; length_skin, width_skin, height_skin, fat), SurfaceAreas(; total))
 end
 function geometry(shape::Plate, fibrous_layer::FibrousLayer, fat_layer::FatLayer)
     volume = shape.mass / shape.density
-    length_skin = (volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3)
+    length_skin = cbrt(volume * shape.axis_ratio_b * shape.axis_ratio_c)
     width_skin = length_skin / shape.axis_ratio_b
     height_skin = length_skin / shape.axis_ratio_c
     fat_mass = shape.mass * fat_layer.fraction
     fat_volume = fat_mass / fat_layer.density
     flesh_volume = volume - fat_volume
-    width_flesh = (flesh_volume * shape.axis_ratio_b * shape.axis_ratio_c)^(1 / 3) / shape.axis_ratio_b
+    width_flesh = cbrt(flesh_volume * shape.axis_ratio_b * shape.axis_ratio_c) / shape.axis_ratio_b
     fat = (width_skin - width_flesh) / 2
     length_fur = length_skin + fibrous_layer.thickness * 2
     width_fur = width_skin + fibrous_layer.thickness * 2

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -10,13 +10,13 @@ end
 
 function geometry(shape::Sphere, ::Naked)
     volume = shape.mass / shape.density
-    radius_skin = ((3 / 4) * volume / π) ^ (1 / 3)
+    radius_skin = cbrt((3 / 4) * volume / π)
     total = surface_area(shape, radius_skin)
     return Geometry(volume, (; radius_skin), SurfaceAreas(; total))
 end
 function geometry(shape::Sphere, fibrous_layer::FibrousLayer)
     volume = shape.mass / shape.density
-    radius_skin = ((3 / 4)* volume / π) ^ (1 / 3)
+    radius_skin = cbrt((3 / 4) * volume / π)
     radius_fur = radius_skin + fibrous_layer.thickness
     total = surface_area(shape, radius_fur)
     skin = surface_area(shape, radius_skin)
@@ -29,8 +29,8 @@ function geometry(shape::Sphere, fat_layer::FatLayer)
     fat_mass = shape.mass * fat_layer.fraction
     fat_volume = fat_mass / fat_layer.density
     flesh_volume = volume - fat_volume
-    radius_skin = ((3 / 4) * volume / π) ^ (1 / 3)
-    radius_flesh = ((3 / 4) * flesh_volume / π) ^ (1 / 3)
+    radius_skin = cbrt((3 / 4) * volume / π)
+    radius_flesh = cbrt((3 / 4) * flesh_volume / π)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_skin)
     return Geometry(volume, (; radius_skin, fat), SurfaceAreas(; total))
@@ -40,9 +40,9 @@ function geometry(shape::Sphere, fibrous_layer::FibrousLayer, fat_layer::FatLaye
     fat_mass = shape.mass * fat_layer.fraction
     fat_volume = fat_mass / fat_layer.density
     flesh_volume = volume - fat_volume
-    radius_skin = ((3 / 4) * volume / π) ^ (1 / 3)
+    radius_skin = cbrt((3 / 4) * volume / π)
     radius_fur = radius_skin + fibrous_layer.thickness
-    radius_flesh = ((3 / 4) * flesh_volume / π) ^ (1 / 3)
+    radius_flesh = cbrt((3 / 4) * flesh_volume / π)
     fat = radius_skin - radius_flesh
     total = surface_area(shape, radius_fur)
     skin = surface_area(shape, radius_skin)


### PR DESCRIPTION
Usinge `sqrt` and `cbrt` is friendly to unitful where `x ^ 1/3` is not.

Seems these methods could all use some tidying up too, will do that in another PR.